### PR TITLE
Add backward motion label definitions

### DIFF
--- a/labels/cam_motion/camera_centric_movement/backward/has_backward_wrt_camera.json
+++ b/labels/cam_motion/camera_centric_movement/backward/has_backward_wrt_camera.json
@@ -1,0 +1,63 @@
+{
+    "label": "Has Backward Movement (Relative to Camera)",
+    "label_name": "has_backward_wrt_camera",
+    "def_question": [
+        "Does the camera move backward (not zooming out) with respect to the initial frame?",
+        "Does the camera move backward in space based on its starting position?",
+        "Is the camera moving backward (not zooming out) with respect to itself, creating a noticeable parallax effect?",
+        "Is the backward motion of the camera clear in this shot by comparing the start and end of the shot?",
+        "Is the camera dollying out with respect to itself?",
+        "Is the camera pulling back with respect to itself?"
+    ],
+    "alt_question": [
+        "Does the camera move backward (not zooming out)?",
+        "Is the camera moving backward?",
+        "Is there clear backward movement when comparing the start and end of the shot?",
+        "Does the camera travel backward in space, rather than zooming out?",
+        "Is the camera pulling back through the space?",
+        "Does the shot feature a clear backward motion of the camera?",
+        "Is the camera's movement progressing backward rather than forward?",
+        "Is the backward motion of the camera clear in this shot?",
+        "Does the camera travel backward in space, rather than zooming out?",
+        "Is the camera retreating in the scene?",
+        "Does the perspective shift backward rather than relying on zoom?",
+        "Is the camera physically traveling backward instead of adjusting focal length?",
+        "Is the camera pulling back, creating a strong sense of depth?"
+    ],
+    "def_prompt": [
+        "A video where the camera moves backward (not zooming out) with respect to the initial frame.",
+        "A shot where the camera moves backward in space based on its starting position.",
+        "A video where the camera moves backward (not zooming out) with respect to itself, creating a noticeable parallax effect.",
+        "A scene where the backward motion of the camera is clear by comparing the start and end of the shot.",
+        "The camera pulls back with respect to itself.",
+        "The camera dollies backward with respect to itself.",
+        "A video where the camera dolly moves backward with respect to itself."
+    ],
+    "alt_prompt": [
+        "A shot where the camera moves backward (not zooming out).",
+        "A video where the camera is moving backward.",
+        "The camera moves backward in space based on its starting position.",
+        "The camera pulls back through the space.",
+        "The camera moves backward.",
+        "Camera retreats backward.",
+        "A scene where there is clear backward movement when comparing the start and end of the shot.",
+        "A video where the camera travels backward in space, rather than zooming out.",
+        "A shot where the camera pulls back through the space.",
+        "A video where the shot features a clear backward motion of the camera.",
+        "A scene where the camera's movement progresses backward rather than forward.",
+        "A video where the backward motion of the camera is clear.",
+        "A shot where the camera travels backward in space rather than zooming out.",
+        "A scene where the camera is retreating in the shot.",
+        "A video where the perspective shifts backward rather than relying on zoom.",
+        "A shot where the camera physically travels backward instead of adjusting focal length.",
+        "A video where the camera pulls back, creating a strong sense of depth."
+    ],
+    "pos_rule_str": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward_cam_frame == 'backward'",
+    "neg_rule_str": "(self.cam_motion.camera_movement in ['major_simple','no'] and self.cam_motion.camera_forward_backward_cam_frame != 'backward') or (self.cam_motion.camera_movement in ['major_complex'] and self.cam_motion.camera_forward_backward_cam_frame == 'forward') and self.cam_motion.steadiness not in ['unsteady','very_unsteady']",
+    "easy_neg_rule_str": {
+        "moving_forward": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward_cam_frame == 'forward' and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    },
+    "hard_neg_rule_str": {
+        "zooming_out": "self.cam_motion.camera_movement in ['major_simple'] and self.cam_motion.camera_forward_backward_cam_frame != 'backward' and self.cam_motion.camera_zoom == 'out' and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/backward/only_backward_wrt_camera.json
+++ b/labels/cam_motion/camera_centric_movement/backward/only_backward_wrt_camera.json
@@ -1,0 +1,59 @@
+{
+    "label": "Only Backward Movement (Relative to Camera)",
+    "label_name": "only_backward_wrt_camera",
+    "def_question": [
+        "Does the camera move only backward (not zooming out) with respect to the initial frame?",
+        "Is backward motion the only camera movement from the initial frame?",
+        "Is there no other camera motion except backward movement relative to the initial frame?",
+        "Does the camera move backward with respect to itself without any other movement or zooming?",
+        "Is the camera only moving backward relative to the first frame?",
+        "Is the camera only dollying out with respect to itself?",
+        "Is the camera only pulling back with respect to itself?",
+        "Is the camera only moving backward without zooming out relative to the first frame?"
+    ],
+    "alt_question": [
+        "Is the camera only moving backward?",
+        "Is the camera only moving backward (not zooming out) in the scene, creating a noticeable parallax effect?",
+        "Is backward motion the only camera movement in this shot?",
+        "Does the camera travel only backward in space, rather than zooming out?",
+        "Is the camera exclusively moving backward relative to its initial position?",
+        "Does the camera retreat in a straight backward direction without any other motions?",
+        "Is the only movement in this shot a backward motion?",
+        "Is there no side, tilt, or zoom adjustments while moving backward?",
+        "Does the camera pull back without any vertical or lateral changes?",
+        "Does the tracking movement consist only of a backward pull?",
+        "Is the camera strictly retreating backward with no other motion applied?",
+        "Does the shot feature only a single directional backward movement?"
+    ],
+    "def_prompt": [
+        "A video where the camera moves only backward (not zooming out) with respect to the initial frame.",
+        "A shot where the camera retreats in space relative to its starting position without any additional motion.",
+        "A video where the camera exclusively moves backward with respect to the initial frame, creating a noticeable parallax effect.",
+        "A scene where the camera pulls back with respect to itself without any lateral or vertical movement.",
+        "The camera only dollying backward with respect to itself.",
+        "The camera only pulls back with respect to itself."
+    ],
+    "alt_prompt": [
+        "A shot where the camera moves backward with no additional movement type.",
+        "The camera moves backward without incorporating other movement types.",
+        "The camera dollies backward.",
+        "The camera retreats backward.",
+        "Camera moves backward.",
+        "A shot where the backward motion is the only movement present in the scene.",
+        "A shot where the camera moves strictly backward without side-to-side or vertical adjustments.",
+        "A video where the camera retreats in a single direction without any motion complexity.",
+        "A scene where the camera moves straight back without tilting or panning.",
+        "A video where the camera strictly maintains backward movement with no deviation.",
+        "A shot where the tracking movement is purely backward without other motions.",
+        "A scene where the only motion is the camera pulling back in a single direction."
+    ],
+    "pos_rule_str": "self.cam_motion.camera_movement in ['major_simple'] and self.cam_motion.camera_forward_backward_cam_frame == 'backward' and self.cam_motion.check_if_no_motion_cam_frame(exclude=['forward_backward']) and self.cam_motion.steadiness not in ['unsteady','very_unsteady']",
+    "neg_rule_str": "self.cam_motion.camera_forward_backward_cam_frame != 'backward' or not self.cam_motion.check_if_no_motion_cam_frame(exclude=['forward_backward']) or self.cam_motion.camera_movement not in ['major_simple']",
+    "easy_neg_rule_str": {
+        "moving_forward": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward_cam_frame == 'forward'"
+    },
+    "hard_neg_rule_str": {
+        "zooming_out": "self.cam_motion.camera_movement in ['major_simple'] and self.cam_motion.camera_forward_backward_cam_frame != 'backward' and self.cam_motion.camera_zoom == 'out'",
+        "compound_motion_with_backward": "self.cam_motion.camera_movement in ['major_simple'] and self.cam_motion.camera_forward_backward_cam_frame == 'backward' and not self.cam_motion.check_if_no_motion_cam_frame(exclude=['forward_backward'])"
+    }
+}

--- a/labels/cam_motion/ground_centric_movement/backward/has_backward_wrt_ground.json
+++ b/labels/cam_motion/ground_centric_movement/backward/has_backward_wrt_ground.json
@@ -1,0 +1,63 @@
+{
+    "label": "Has Backward Movement (Relative to Ground, Bird's/Worm's Eye Views Not Included)",
+    "label_name": "has_backward_wrt_ground",
+    "def_question": [
+        "Does the camera move backward (not zooming out) in the scene?",
+        "Is the camera moving backward in the scene?",
+        "Is the camera moving backward?",
+        "Is the camera moving backward, creating a noticeable parallax effect?",
+        "Is the camera moving backward (not zooming out) in the scene, creating a noticeable parallax effect?",
+        "Does the camera move in the backward direction relative to the ground?",
+        "Is the camera pulling back through the space?",
+        "Is the camera pulling out?",
+        "Is the camera dollying out?",
+        "Is the camera dollying backward?",
+        "Does the shot feature a clear backward motion of the camera?",
+        "Is the camera's movement progressing backward rather than forward?",
+        "Is the backward motion of the camera clear in this shot?",
+        "Does the camera travel backward in space, rather than zooming out?"
+    ],
+    "alt_question": [
+        "Is the camera retreating in the scene?",
+        "Does the perspective shift backward rather than relying on zoom?",
+        "Is the camera physically traveling backward instead of adjusting focal length?",
+        "Is the camera retreating, creating a strong sense of depth?"
+    ],
+    "def_prompt": [
+        "A shot where the camera moves backward, rather than zooming out.",
+        "A video where the camera travels backward, creating noticeable parallax.",
+        "A scene where the camera moves physically backward instead of zooming.",
+        "A tracking shot where the camera moves backward relative to the ground plane.",
+        "A shot where the camera moves straight back, maintaining a sense of backward motion.",
+        "A video where the camera moves backward (not zooming out) in the scene.",
+        "A shot where the camera is moving backward within the scene.",
+        "A video where the camera moves backward, creating a noticeable parallax effect.",
+        "A shot where the camera moves in the backward direction relative to the ground.",
+        "A video where the camera pulls back through space.",
+        "A scene where the camera pulls out.",
+        "A video where the camera performs a dolly-out motion.",
+        "A shot where the camera dollies backward.",
+        "The camera dollies out, moving backward in the scene.",
+        "A video where the camera progresses backward rather than forward.",
+        "A shot where the backward motion of the camera is clearly visible.",
+        "A video where the camera travels backward in space rather than zooming out."
+    ],
+    "alt_prompt": [
+        "A scene where the shot features a clear backward motion of the camera.",
+        "A shot where the camera dolly moves straight back.",
+        "A video where the camera moves in a backward direction within the scene.",
+        "A shot where the camera retreats rather than zooming out.",
+        "A video where the camera progresses backward, creating depth.",
+        "A scene where the camera moves back rather than pushing forward.",
+        "A shot where the perspective shifts backward dynamically.",
+        "A video where the camera maintains a continuous backward movement."
+    ],
+    "pos_rule_str": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward == 'backward' and self.cam_setup.camera_angle_start not in ['bird_eye_angle', 'worm_eye_angle', 'unknown']",
+    "neg_rule_str": "((self.cam_motion.camera_movement in ['major_simple','no'] and self.cam_motion.camera_forward_backward != 'backward') or (self.cam_motion.camera_movement in ['major_complex'] and self.cam_motion.camera_forward_backward == 'forward')) and self.cam_setup.camera_angle_start not in ['bird_eye_angle', 'worm_eye_angle', 'unknown'] and self.cam_motion.steadiness not in ['unsteady','very_unsteady']",
+    "easy_neg_rule_str": {
+        "moving_forward": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward == 'forward' and self.cam_setup.camera_angle_start not in ['bird_eye_angle', 'worm_eye_angle', 'unknown'] and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    },
+    "hard_neg_rule_str": {
+        "zooming_out": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward != 'backward' and self.cam_motion.camera_zoom == 'out' and self.cam_setup.camera_angle_start not in ['bird_eye_angle', 'worm_eye_angle', 'unknown'] and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    }
+}

--- a/labels/cam_motion/ground_centric_movement/backward/has_backward_wrt_ground_birds_worms_included.json
+++ b/labels/cam_motion/ground_centric_movement/backward/has_backward_wrt_ground_birds_worms_included.json
@@ -1,0 +1,49 @@
+{
+    "label": "Has Backward Movement (Relative to Ground, Bird's/Worm's Eye Views Included)",
+    "label_name": "has_backward_wrt_ground_birds_worms_included",
+    "def_question": [
+        "Does the camera move backward (not zooming out) in the scene, or move south if it's a bird's eye view, or move north if it's a worm's eye view?",
+        "Does the camera move backward (not zooming out) in the scene, or move downward if it's a bird's eye view, or move upward if it's a worm's eye view?",
+        "Is the camera moving backward in the scene (south in a bird's eye view or north in a worm's eye view)?"
+    ],
+    "alt_question": [
+        "Is the camera moving backward in the scene?",
+        "Is the camera moving backward?",
+        "Is the camera moving backward (not zooming out) in the scene, creating a noticeable parallax effect?",
+        "Is the backward motion of the camera clear in this shot?",
+        "Does the camera travel backward in space, rather than zooming out?",
+        "Is the camera retreating in the scene?",
+        "Does the camera move in the backward direction relative to the ground?",
+        "Is the camera's movement progressing backward rather than forward?",
+        "Is the camera pulling back through the space?",
+        "Does the shot feature a clear backward motion of the camera?",
+        "Does the perspective shift backward rather than relying on zoom?",
+        "Is the camera physically traveling backward instead of adjusting focal length?",
+        "Is the camera retreating, creating a strong sense of depth?"
+    ],
+    "def_prompt": [
+        "A video where the camera moves backward (not zooming out) in the scene or moves south in a bird's eye view or north in a worm's eye view.",
+        "A video where the camera moves backward (not zooming out) in the scene or moves south in a bird's eye view or north in a worm's eye view, creating a noticeable parallax effect.",
+        "A tracking shot where the camera moves backward (not zooming out) relative to the ground plane."
+    ],
+    "alt_prompt": [
+        "A shot where the camera moves backward, not zooming out.",
+        "A shot where the camera moves backward, rather than zooming out.",
+        "A video where the camera travels backward, creating noticeable parallax.",
+        "A scene where the camera moves physically backward instead of zooming.",
+        "A video where the camera moves in a backward direction within the scene.",
+        "A shot where the camera retreats rather than zooming out.",
+        "A video where the camera progresses backward, creating depth.",
+        "A scene where the camera moves back rather than pushing forward.",
+        "A shot where the perspective shifts backward dynamically.",
+        "A video where the camera maintains a continuous backward movement."
+    ],
+    "pos_rule_str": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward == 'backward'",
+    "neg_rule_str": "(self.cam_motion.camera_movement in ['major_simple','no'] and self.cam_motion.steadiness not in ['unsteady','very_unsteady'] and self.cam_motion.camera_forward_backward != 'backward') or (self.cam_motion.camera_movement in ['major_complex'] and self.cam_motion.camera_forward_backward == 'forward')",
+    "easy_neg_rule_str": {
+        "moving_forward": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward == 'forward' and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    },
+    "hard_neg_rule_str": {
+        "zooming_out": "self.cam_motion.camera_movement in ['major_simple'] and self.cam_motion.camera_forward_backward != 'backward' and self.cam_motion.camera_zoom == 'out' and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    }
+}

--- a/labels/cam_motion/ground_centric_movement/backward/only_backward_wrt_ground.json
+++ b/labels/cam_motion/ground_centric_movement/backward/only_backward_wrt_ground.json
@@ -1,0 +1,49 @@
+{
+    "label": "Only Backward Movement (Relative to Ground, Bird's/Worm's Eye Views Not Included)",
+    "label_name": "only_backward_wrt_ground",
+    "def_question": [
+        "Does the camera only move backward (not zooming out) with respect to the ground?",
+        "Is the camera only moving backward with respect to the ground?",
+        "Is the camera only moving backward without zooming out relative to the ground?",
+        "Is the camera only pulling back with respect to the ground?",
+        "Is the camera only dollying backward (not zooming out) relative to the ground?"
+    ],
+    "alt_question": [
+        "Is the camera only moving backward in the scene?",
+        "Is the camera only moving backward (not zooming out) in the scene, creating a noticeable parallax effect?",
+        "Relative to ground, is backward motion the only camera movement in this shot?",
+        "Does the camera travel only backward in space, rather than zooming out?",
+        "Is the camera exclusively moving backward in the scene?",
+        "Does the camera move straight back without any other motion?",
+        "Is the camera's motion restricted to only backward movement?",
+        "Does the tracking movement involve only a backward pull?",
+        "Is the camera moving back without any vertical or lateral adjustments?"
+    ],
+    "def_prompt": [
+        "A video where the camera only moves backward (not zooming out) relative to the ground.",
+        "A shot where the camera moves straight back with respect to the ground without any other motion.",
+        "A video where the camera exclusively moves backward relative to the ground plane, creating a noticeable parallax effect.",
+        "A scene where the camera moves only backward relative to the ground, avoiding zooming or other motions.",
+        "The camera is only dollying backward with respect to the ground.",
+        "The camera is only pulling back with respect to the ground."
+    ],
+    "alt_prompt": [
+        "A tracking shot where the camera moves backward without incorporating other movement types.",
+        "A shot where the backward motion is the only movement present in the scene.",
+        "A shot where the camera moves strictly backward without lateral or vertical movement.",
+        "A video where the camera retreats in a single direction without any other adjustments.",
+        "A scene where the camera moves back without shifting side to side.",
+        "A video where the camera strictly maintains backward movement with no deviation.",
+        "A shot where the tracking movement is purely backward with no other motion.",
+        "A scene where the only movement present is the camera pulling back."
+    ],
+    "pos_rule_str": "self.cam_motion.camera_movement in ['major_simple'] and self.cam_motion.camera_forward_backward == 'backward' and self.cam_motion.check_if_no_motion(exclude=['forward_backward']) and self.cam_motion.steadiness not in ['unsteady','very_unsteady'] and self.cam_setup.camera_angle_start not in ['bird_eye_angle', 'worm_eye_angle', 'unknown']",
+    "neg_rule_str": "self.cam_motion.camera_forward_backward != 'backward' or not self.cam_motion.check_if_no_motion(exclude=['forward_backward']) or self.cam_motion.camera_movement not in ['major_simple'] and self.cam_setup.camera_angle_start not in ['bird_eye_angle', 'worm_eye_angle', 'unknown']",
+    "easy_neg_rule_str": {
+        "moving_forward": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward == 'forward' and self.cam_setup.camera_angle_start not in ['bird_eye_angle', 'worm_eye_angle', 'unknown']"
+    },
+    "hard_neg_rule_str": {
+        "zooming_out": "self.cam_motion.camera_movement in ['major_simple'] and self.cam_motion.camera_forward_backward != 'backward' and self.cam_motion.camera_zoom == 'out' and self.cam_setup.camera_angle_start not in ['bird_eye_angle', 'worm_eye_angle', 'unknown']",
+        "compound_motion_with_backward": "self.cam_motion.camera_movement in ['major_simple'] and self.cam_motion.camera_forward_backward == 'backward' and not self.cam_motion.check_if_no_motion(exclude=['forward_backward']) and self.cam_setup.camera_angle_start not in ['bird_eye_angle', 'worm_eye_angle', 'unknown']"
+    }
+}

--- a/labels/cam_motion/ground_centric_movement/backward/only_backward_wrt_ground_birds_worms_included.json
+++ b/labels/cam_motion/ground_centric_movement/backward/only_backward_wrt_ground_birds_worms_included.json
@@ -1,0 +1,58 @@
+{
+    "label": "Only Backward Movement (Relative to Ground, Bird's/Worm's Eye Views Included)",
+    "label_name": "only_backward_wrt_ground_birds_worms_included",
+    "def_question": [
+        "Does the camera move only backward (not zooming out) in the scene, or only southward in a bird's eye view, or only northward in a worm's eye view?",
+        "Does the camera move only backward (not zooming out) in the scene, or only downward in a bird's eye view, or only upward in a worm's eye view?",
+        "Does the camera move only backward (not zooming out) in the scene, or only move south if it's a bird's eye view, or only move north if it's a worm's eye view?",
+        "Is the camera only moving backward in the scene (south in a bird's eye view or north in a worm's eye view)?"
+    ],
+    "alt_question": [
+        "Is the camera only moving backward in the scene?",
+        "Is the camera only moving backward?",
+        "Is the camera only moving backward (not zooming out) in the scene, creating a noticeable parallax effect?",
+        "Is backward motion the only camera movement in this shot?",
+        "Does the camera travel only backward in space, rather than zooming out?",
+        "Is the camera moving exclusively backward in the scene?",
+        "Does the camera retreat in a straight backward direction without other motions?",
+        "Is the only movement in this shot a backward motion?",
+        "Does the scene feature a camera that only moves backward without lateral or vertical movement?",
+        "Is the camera's motion restricted to a single backward direction?",
+        "Does the tracking movement solely involve pulling back?",
+        "Is the camera free from side-to-side or up-and-down movement while going backward?"
+    ],
+    "def_prompt": [
+        "A video where the camera moves only backward (not zooming out) in the scene, or only south in a bird's eye view or north in a worm's eye view.",
+        "A video where the camera only moves backward (not zooming out) in the scene or moves south in a bird's eye view or north in a worm's eye view.",
+        "A video where the camera only moves backward (not zooming out) in the scene or moves south in a bird's eye view or north in a worm's eye view, creating a noticeable parallax effect.",
+        "A tracking shot where the camera only moves backward (not zooming out) relative to the ground plane."
+    ],
+    "alt_prompt": [
+        "A shot where the camera moves backward without shifting side-to-side.",
+        "A video where the camera moves back with no other directional changes.",
+        "A scene where the camera pulls back while maintaining a strict backward trajectory.",
+        "A video where the camera strictly maintains backward movement without deviation.",
+        "A shot where the backward motion is the only movement present in the scene.",
+        "A video where the camera only moves backward in the scene.",
+        "A shot where the camera moves exclusively backward without any other motion.",
+        "A video where the camera moves only backward (not zooming out), creating a noticeable parallax effect.",
+        "A scene where backward motion is the only camera movement present.",
+        "A shot where the camera travels only backward in space, rather than zooming out.",
+        "A video where the camera retreats in a straight backward direction without lateral or vertical movement.",
+        "A scene where the camera moves backward without any additional motion.",
+        "A tracking shot where the camera's movement is restricted to a single backward direction.",
+        "A shot where the tracking movement solely involves pulling back.",
+        "A video where the camera is free from side-to-side or up-and-down movement while going backward.",
+        "A scene where the only movement present is the backward motion of the camera.",
+        "A video where the camera maintains strict backward motion with no deviation."
+    ],
+    "pos_rule_str": "self.cam_motion.camera_movement in ['major_simple'] and self.cam_motion.camera_forward_backward == 'backward' and self.cam_motion.check_if_no_motion(exclude=['forward_backward']) and self.cam_motion.steadiness not in ['unsteady','very_unsteady']",
+    "neg_rule_str": "self.cam_motion.camera_forward_backward != 'backward' or not self.cam_motion.check_if_no_motion(exclude=['forward_backward']) or self.cam_motion.camera_movement not in ['major_simple']",
+    "easy_neg_rule_str": {
+        "moving_forward": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward == 'forward'"
+    },
+    "hard_neg_rule_str": {
+        "zooming_out": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_forward_backward != 'backward' and self.cam_motion.camera_zoom == 'out'",
+        "compound_motion_with_backward": "self.cam_motion.camera_movement in ['major_simple'] and self.cam_motion.camera_forward_backward == 'backward' and not self.cam_motion.check_if_no_motion(exclude=['forward_backward'])"
+    }
+}


### PR DESCRIPTION
Added JSON files for backward camera motion in both camera-centric and ground-centric contexts:
- Added camera_centric_movement/backward/ with has/only backward motion labels
- Added ground_centric_movement/backward/ with has/only backward motion labels (with and without bird's/worm's eye views)
- Maintained parallel structure with forward motion labels
- Updated rules and descriptions for backward motion