### PR TITLE
Add pan left/right camera motion labels

### DIFF
--- a/labels/cam_motion/camera_centric_movement/pan_left/has_pan_left.json
+++ b/labels/cam_motion/camera_centric_movement/pan_left/has_pan_left.json
@@ -1,0 +1,52 @@
+{
+    "label": "Has Pan Left Movement",
+    "label_name": "has_pan_left",
+    "def_question": [
+        "Does the camera pan left in the scene?",
+        "Is the camera panning left in the scene?",
+        "Is this a leftward panning shot?",
+        "Does the camera execute a pan movement to the left?",
+        "Does the camera pan left (not move/truck left)?",
+        "Is this a left panning motion (not lateral movement)?",
+        "Does the shot feature a camera pan to the left (rotating, not moving sideways)?",
+        "Is the camera rotating left on its axis (not tracking left)?"
+    ],
+    "alt_question": [
+        "Is the camera rotating to the left?",
+        "Does the view shift from right to left?",
+        "Is the camera turning leftward?",
+        "Does the camera sweep to the left?",
+        "Is the camera swiveling left?",
+        "Is the camera pivoting left?",
+        "Does the camera move horizontally from right to left?",
+        "Is this a horizontal camera movement from right to left?"
+    ],
+    "def_prompt": [
+        "A shot where the camera pans left.",
+        "A video featuring a leftward panning movement.",
+        "A scene where the camera pans left (not trucks/moves left).",
+        "A shot with a left panning motion (camera rotating, not moving sideways).",
+        "A video where the camera rotates left on its axis, not tracking left.",
+        "A scene featuring a left panning camera movement (not lateral movement).",
+        "A shot where the camera pans left without sideways translation.",
+        "A video demonstrating a pure left panning motion (rotating, not tracking)."
+    ],
+    "alt_prompt": [
+        "A scene where the camera rotates to the left.",
+        "A shot where the view shifts from right to left.",
+        "A video where the camera turns leftward.",
+        "A scene where the camera sweeps to the left.",
+        "A shot with leftward camera rotation.",
+        "A video where the camera swivels left.",
+        "A scene where the camera pivots left.",
+        "A shot with horizontal camera movement from right to left."
+    ],
+    "pos_rule_str": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_pan == 'left'",
+    "neg_rule_str": "((self.cam_motion.camera_movement in ['major_simple','no'] and self.cam_motion.camera_pan != 'left') or (self.cam_motion.camera_movement in ['major_complex'] and self.cam_motion.camera_pan == 'right')) and self.cam_motion.steadiness not in ['unsteady','very_unsteady'] and not self.cam_motion.check_if_any_motion(include=['arc', 'crane'])",
+    "easy_neg_rule_str": {
+        "panning_right": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_pan == 'right' and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    },
+    "hard_neg_rule_str": {
+        "moving_left": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_pan != 'left' and self.cam_motion.camera_left_right == 'left' and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/pan_left/only_pan_left.json
+++ b/labels/cam_motion/camera_centric_movement/pan_left/only_pan_left.json
@@ -1,0 +1,50 @@
+{
+    "label": "Only Pan Left Movement",
+    "label_name": "only_pan_left",
+    "def_question": [
+        "Does the camera only pan left in the scene, without any other camera movements?",
+        "Is the camera movement purely a leftward pan?",
+        "Is this exclusively a left panning shot?",
+        "Does the camera only execute a pan movement to the left?",
+        "Is this purely a left panning motion (no tracking or other movements)?",
+        "Does the shot feature only a camera pan to the left (rotating, not moving sideways)?",
+        "Is the camera only rotating left on its axis (no tracking or other movements)?"
+    ],
+    "alt_question": [
+        "Is the camera only rotating to the left?",
+        "Does the camera just turn leftward?",
+        "Is the movement limited to a left rotation?",
+        "Is this just a leftward sweep of the camera?",
+        "Is the camera only swiveling left?",
+        "Is the camera just pivoting left?",
+        "Is this strictly a horizontal movement from right to left?",
+        "Does the camera only move horizontally from right to left?"
+    ],
+    "def_prompt": [
+        "A shot where the camera only pans left.",
+        "A video featuring exclusively leftward panning movement.",
+        "A scene with only a left panning motion (no tracking or other movements).",
+        "A shot containing only a leftward pan (camera rotating, not moving sideways).",
+        "A video where the camera only rotates left on its axis.",
+        "A scene with nothing but a left panning camera movement (no lateral movement).",
+        "A shot demonstrating exclusively left panning motion (no tracking).",
+        "A video with pure left panning motion (rotating only, no translation)."
+    ],
+    "alt_prompt": [
+        "A scene where the camera only rotates to the left.",
+        "A shot with just a leftward turning motion.",
+        "A video showing only a left sweeping movement.",
+        "A scene limited to leftward camera rotation.",
+        "A shot where the camera just swivels left.",
+        "A video where the camera only pivots left.",
+        "A scene with just horizontal camera movement from right to left."
+    ],
+    "pos_rule_str": "self.cam_motion.camera_movement == 'major_simple' and self.cam_motion.camera_pan == 'left' and not self.cam_motion.check_if_any_motion(exclude=['pan'])",
+    "neg_rule_str": "(self.cam_motion.camera_movement == 'major_simple' and self.cam_motion.camera_pan != 'left') or (self.cam_motion.camera_movement == 'major_complex') and self.cam_motion.steadiness not in ['unsteady','very_unsteady']",
+    "easy_neg_rule_str": {
+        "only_panning_right": "self.cam_motion.camera_movement == 'major_simple' and self.cam_motion.camera_pan == 'right' and not self.cam_motion.check_if_any_motion(exclude=['pan']) and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    },
+    "hard_neg_rule_str": {
+        "pan_left_with_other": "self.cam_motion.camera_movement == 'major_complex' and self.cam_motion.camera_pan == 'left' and self.cam_motion.camera_left_right == 'left' and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/pan_right/has_pan_right.json
+++ b/labels/cam_motion/camera_centric_movement/pan_right/has_pan_right.json
@@ -1,0 +1,52 @@
+{
+    "label": "Has Pan Right Movement",
+    "label_name": "has_pan_right",
+    "def_question": [
+        "Does the camera pan right in the scene?",
+        "Is the camera panning right in the scene?",
+        "Is this a rightward panning shot?",
+        "Does the camera execute a pan movement to the right?",
+        "Does the camera pan right (not move/truck right)?",
+        "Is this a right panning motion (not lateral movement)?",
+        "Does the shot feature a camera pan to the right (rotating, not moving sideways)?",
+        "Is the camera rotating right on its axis (not tracking right)?"
+    ],
+    "alt_question": [
+        "Is the camera rotating to the right?",
+        "Does the view shift from left to right?",
+        "Is the camera turning rightward?",
+        "Does the camera sweep to the right?",
+        "Is the camera swiveling right?",
+        "Is the camera pivoting right?",
+        "Does the camera move horizontally from left to right?",
+        "Is this a horizontal camera movement from left to right?"
+    ],
+    "def_prompt": [
+        "A shot where the camera pans right.",
+        "A video featuring a rightward panning movement.",
+        "A scene where the camera pans right (not trucks/moves right).",
+        "A shot with a right panning motion (camera rotating, not moving sideways).",
+        "A video where the camera rotates right on its axis, not tracking right.",
+        "A scene featuring a right panning camera movement (not lateral movement).",
+        "A shot where the camera pans right without sideways translation.",
+        "A video demonstrating a pure right panning motion (rotating, not tracking)."
+    ],
+    "alt_prompt": [
+        "A scene where the camera rotates to the right.",
+        "A shot where the view shifts from left to right.",
+        "A video where the camera turns rightward.",
+        "A scene where the camera sweeps to the right.",
+        "A shot with rightward camera rotation.",
+        "A video where the camera swivels right.",
+        "A scene where the camera pivots right.",
+        "A shot with horizontal camera movement from left to right."
+    ],
+    "pos_rule_str": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_pan == 'right'",
+    "neg_rule_str": "((self.cam_motion.camera_movement in ['major_simple','no'] and self.cam_motion.camera_pan != 'right') or (self.cam_motion.camera_movement in ['major_complex'] and self.cam_motion.camera_pan == 'left')) and self.cam_motion.steadiness not in ['unsteady','very_unsteady'] and not self.cam_motion.check_if_any_motion(include=['arc', 'crane'])",
+    "easy_neg_rule_str": {
+        "panning_left": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_pan == 'left' and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    },
+    "hard_neg_rule_str": {
+        "moving_right": "self.cam_motion.camera_movement in ['major_simple','major_complex'] and self.cam_motion.camera_pan != 'right' and self.cam_motion.camera_left_right == 'right' and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/pan_right/only_pan_right.json
+++ b/labels/cam_motion/camera_centric_movement/pan_right/only_pan_right.json
@@ -1,0 +1,50 @@
+{
+    "label": "Only Pan Right Movement",
+    "label_name": "only_pan_right",
+    "def_question": [
+        "Does the camera only pan right in the scene, without any other camera movements?",
+        "Is the camera movement purely a rightward pan?",
+        "Is this exclusively a right panning shot?",
+        "Does the camera only execute a pan movement to the right?",
+        "Is this purely a right panning motion (no tracking or other movements)?",
+        "Does the shot feature only a camera pan to the right (rotating, not moving sideways)?",
+        "Is the camera only rotating right on its axis (no tracking or other movements)?"
+    ],
+    "alt_question": [
+        "Is the camera only rotating to the right?",
+        "Does the camera just turn rightward?",
+        "Is the movement limited to a right rotation?",
+        "Is this just a rightward sweep of the camera?",
+        "Is the camera only swiveling right?",
+        "Is the camera just pivoting right?",
+        "Is this strictly a horizontal movement from left to right?",
+        "Does the camera only move horizontally from left to right?"
+    ],
+    "def_prompt": [
+        "A shot where the camera only pans right.",
+        "A video featuring exclusively rightward panning movement.",
+        "A scene with only a right panning motion (no tracking or other movements).",
+        "A shot containing only a rightward pan (camera rotating, not moving sideways).",
+        "A video where the camera only rotates right on its axis.",
+        "A scene with nothing but a right panning camera movement (no lateral movement).",
+        "A shot demonstrating exclusively right panning motion (no tracking).",
+        "A video with pure right panning motion (rotating only, no translation)."
+    ],
+    "alt_prompt": [
+        "A scene where the camera only rotates to the right.",
+        "A shot with just a rightward turning motion.",
+        "A video showing only a right sweeping movement.",
+        "A scene limited to rightward camera rotation.",
+        "A shot where the camera just swivels right.",
+        "A video where the camera only pivots right.",
+        "A scene with just horizontal camera movement from left to right."
+    ],
+    "pos_rule_str": "self.cam_motion.camera_movement == 'major_simple' and self.cam_motion.camera_pan == 'right' and not self.cam_motion.check_if_any_motion(exclude=['pan'])",
+    "neg_rule_str": "(self.cam_motion.camera_movement == 'major_simple' and self.cam_motion.camera_pan != 'right') or (self.cam_motion.camera_movement == 'major_complex') and self.cam_motion.steadiness not in ['unsteady','very_unsteady']",
+    "easy_neg_rule_str": {
+        "only_panning_left": "self.cam_motion.camera_movement == 'major_simple' and self.cam_motion.camera_pan == 'left' and not self.cam_motion.check_if_any_motion(exclude=['pan']) and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    },
+    "hard_neg_rule_str": {
+        "pan_right_with_other": "self.cam_motion.camera_movement == 'major_complex' and self.cam_motion.camera_pan == 'right' and self.cam_motion.camera_left_right == 'right' and self.cam_motion.steadiness not in ['unsteady','very_unsteady']"
+    }
+}


### PR DESCRIPTION
Added new camera motion labels for panning movements:

- Added `pan_left` and `pan_right` directories under `camera_centric_movement`
- Created `has_pan_left.json`, `only_pan_left.json`, `has_pan_right.json`, and `only_pan_right.json`
- Used proper cinematic terms in def_questions/prompts
- Added clear distinctions between panning (rotation) and tracking/trucking (lateral movement)
- Simplified label names by removing redundant "wrt_camera" suffix
- Added appropriate rules for detecting pan movements