### PR TITLE
Rename up/down folders to upward/downward and add new motion types

### DIFF
--- a/labels/cam_motion/camera_centric_movement/downward/has_downward_wrt_camera.json
+++ b/labels/cam_motion/camera_centric_movement/downward/has_downward_wrt_camera.json
@@ -1,6 +1,6 @@
 {
     "label": "Has Downward Movement (Relative to Camera)",
-    "label_name": "has_down_wrt_camera",
+    "label_name": "has_downward_wrt_camera",
     "def_question": [
         "Does the camera move downward (not tilting down) with respect to the initial frame?",
         "Is the camera moving downward in space based on its starting position?",

--- a/labels/cam_motion/camera_centric_movement/downward/only_downward_wrt_camera.json
+++ b/labels/cam_motion/camera_centric_movement/downward/only_downward_wrt_camera.json
@@ -1,6 +1,6 @@
 {
     "label": "Only Downward Movement (Relative to Camera)",
-    "label_name": "only_down_wrt_camera",
+    "label_name": "only_downward_wrt_camera",
     "def_question": [
         "Does the camera only move downward (not tilting down) with respect to the initial frame?",
         "Is downward motion the only camera movement from the initial frame?",

--- a/labels/cam_motion/camera_centric_movement/leftward/has_leftward.json
+++ b/labels/cam_motion/camera_centric_movement/leftward/has_leftward.json
@@ -1,0 +1,62 @@
+{
+    "label": "Has Leftward Movement",
+    "label_name": "has_leftward",
+    "def_question": [
+        "Does the camera move left in the scene?",
+        "Does the camera move leftward in the scene?",
+        "Does the camera move from right to left?",
+        "Does the camera truck left in the scene?",
+        "Does the camera truck leftward?",
+        "Does the camera truck from right to left?",
+        "Is the camera moving leftward?",
+        "Is the camera trucking left?"
+    ],
+    "alt_question": [
+        "Does the camera move left (not pan left)?",
+        "Does the shot feature a leftward camera movement (moving, not rotating)?",
+        "Is the camera traveling left in the scene?",
+        "Is this a leftward tracking shot?",
+        "Is this a left trucking motion (not panning)?",
+        "Is the camera translating to the left?",
+        "Does the camera physically move from right to left?",
+        "Is the camera tracking leftward?",
+        "Is this a lateral movement to the left?",
+        "Does the camera dolly left?",
+        "Is this a leftward dolly shot?",
+        "Is the camera sliding left?",
+        "Does the camera track from right to left?"
+    ],
+    "def_prompt": [
+        "A shot where the camera moves left.",
+        "A shot where the camera moves leftward.",
+        "A shot where the camera moves from right to left.",
+        "A shot where the camera trucks left.",
+        "A shot where the camera trucks leftward.",
+        "A shot where the camera trucks from right to left.",
+        "The camera moves leftward.",
+        "The camera trucks left in the scene.",
+        "A video featuring leftward camera movement."
+    ],
+    "alt_prompt": [
+        "A scene where the camera moves left (not panning left).",
+        "A shot with leftward camera motion (moving sideways, not rotating).",
+        "A video where the camera travels left.",
+        "A scene featuring leftward tracking movement.",
+        "A shot where the camera trucks left without rotation.",
+        "A video demonstrating leftward camera translation.",
+        "A scene where the camera physically moves from right to left.",
+        "A shot with lateral leftward movement.",
+        "A video where the camera dollies left.",
+        "A scene with leftward tracking motion.",
+        "A shot where the camera slides left.",
+        "A video featuring a left trucking movement."
+    ],
+    "pos_rule_str": "self.cam_motion.left is True",
+    "neg_rule_str": "self.cam_motion.left is False",
+    "easy_neg_rule_str": {
+        "moving_right": "self.cam_motion.right is True"
+    },
+    "hard_neg_rule_str": {
+        "panning_left": "self.cam_motion.pan_left is True and self.cam_motion.left is False"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/leftward/only_leftward.json
+++ b/labels/cam_motion/camera_centric_movement/leftward/only_leftward.json
@@ -1,0 +1,63 @@
+{
+    "label": "Only Leftward Movement",
+    "label_name": "only_leftward",
+    "def_question": [
+        "Does the camera only move left in the scene?",
+        "Does the camera only move leftward, without any other camera movements?",
+        "Does the camera only move from right to left?",
+        "Does the camera only truck left in the scene?",
+        "Does the camera only truck leftward?",
+        "Does the camera only truck from right to left?",
+        "Is the camera movement purely leftward?",
+        "Is this exclusively a leftward tracking shot?"
+    ],
+    "alt_question": [
+        "Is the camera only moving left (no panning or other movements)?",
+        "Does the shot feature only leftward camera movement?",
+        "Is the camera only traveling left in the scene?",
+        "Is this just a leftward tracking shot?",
+        "Is this strictly a left trucking motion?",
+        "Is the camera only translating to the left?",
+        "Does the camera only move physically from right to left?",
+        "Is this just a lateral movement to the left?",
+        "Does the camera only dolly left?",
+        "Is this purely a leftward dolly shot?",
+        "Is the camera only sliding left?",
+        "Is this exclusively a left trucking shot?"
+    ],
+    "def_prompt": [
+        "A shot where the camera only moves left.",
+        "A shot where the camera only moves leftward.",
+        "A shot where the camera only moves from right to left.",
+        "A shot where the camera only trucks left.",
+        "A shot where the camera only trucks leftward.",
+        "A shot where the camera only trucks from right to left.",
+        "The camera only moves leftward.",
+        "The camera only trucks left in the scene.",
+        "A video featuring exclusively leftward camera movement."
+    ],
+    "alt_prompt": [
+        "A scene where the camera only moves left (no panning or other movements).",
+        "A shot with pure leftward camera motion (moving sideways only).",
+        "A video where the camera only travels left.",
+        "A scene featuring only leftward tracking movement.",
+        "A shot where the camera only trucks left.",
+        "A video demonstrating pure leftward camera translation.",
+        "A scene where the camera only moves physically from right to left.",
+        "A shot with only lateral leftward movement.",
+        "A video where the camera only dollies left.",
+        "A scene with pure leftward tracking motion.",
+        "A shot where the camera only slides left.",
+        "A video featuring only left trucking movement."
+    ],
+    "pos_rule_str": "self.cam_motion.left is True and self.cam_motion.check_if_no_motion_cam(exclude=['left'])",
+    "neg_rule_str": "self.cam_motion.left is False or not self.cam_motion.check_if_no_motion_cam(exclude=['left']))",
+    "easy_neg_rule_str": {
+        "moving_right": "self.cam_motion.right is True",
+        "only_moving_right": "self.cam_motion.right is True and self.cam_motion.check_if_no_motion_cam(exclude=['right'])"
+    },
+    "hard_neg_rule_str": {
+        "panning_left": "self.cam_motion.pan_left is True and self.cam_motion.left is False",
+        "compound_motion_with_left": "self.cam_motion.left is True and not self.cam_motion.check_if_no_motion_cam(exclude=['left'])"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/rightward/has_rightward.json
+++ b/labels/cam_motion/camera_centric_movement/rightward/has_rightward.json
@@ -1,0 +1,62 @@
+{
+    "label": "Has Rightward Movement",
+    "label_name": "has_rightward",
+    "def_question": [
+        "Does the camera move right in the scene?",
+        "Does the camera move rightward in the scene?",
+        "Does the camera move from left to right?",
+        "Does the camera truck right in the scene?",
+        "Does the camera truck rightward?",
+        "Does the camera truck from left to right?",
+        "Is the camera moving rightward?",
+        "Is the camera trucking right?"
+    ],
+    "alt_question": [
+        "Does the camera move right (not pan right)?",
+        "Does the shot feature a rightward camera movement (moving, not rotating)?",
+        "Is the camera traveling right in the scene?",
+        "Is this a rightward tracking shot?",
+        "Is this a right trucking motion (not panning)?",
+        "Is the camera translating to the right?",
+        "Does the camera physically move from left to right?",
+        "Is the camera tracking rightward?",
+        "Is this a lateral movement to the right?",
+        "Does the camera dolly right?",
+        "Is this a rightward dolly shot?",
+        "Is the camera sliding right?",
+        "Does the camera track from left to right?"
+    ],
+    "def_prompt": [
+        "A shot where the camera moves right.",
+        "A shot where the camera moves rightward.",
+        "A shot where the camera moves from left to right.",
+        "A shot where the camera trucks right.",
+        "A shot where the camera trucks rightward.",
+        "A shot where the camera trucks from left to right.",
+        "The camera moves rightward.",
+        "The camera trucks right in the scene.",
+        "A video featuring rightward camera movement."
+    ],
+    "alt_prompt": [
+        "A scene where the camera moves right (not panning right).",
+        "A shot with rightward camera motion (moving sideways, not rotating).",
+        "A video where the camera travels right.",
+        "A scene featuring rightward tracking movement.",
+        "A shot where the camera trucks right without rotation.",
+        "A video demonstrating rightward camera translation.",
+        "A scene where the camera physically moves from left to right.",
+        "A shot with lateral rightward movement.",
+        "A video where the camera dollies right.",
+        "A scene with rightward tracking motion.",
+        "A shot where the camera slides right.",
+        "A video featuring a right trucking movement."
+    ],
+    "pos_rule_str": "self.cam_motion.right is True",
+    "neg_rule_str": "self.cam_motion.right is False",
+    "easy_neg_rule_str": {
+        "moving_left": "self.cam_motion.left is True"
+    },
+    "hard_neg_rule_str": {
+        "panning_right": "self.cam_motion.pan_right is True and self.cam_motion.right is False"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/rightward/only_rightward.json
+++ b/labels/cam_motion/camera_centric_movement/rightward/only_rightward.json
@@ -1,0 +1,63 @@
+{
+    "label": "Only Rightward Movement",
+    "label_name": "only_rightward",
+    "def_question": [
+        "Does the camera only move right in the scene?",
+        "Does the camera only move rightward, without any other camera movements?",
+        "Does the camera only move from left to right?",
+        "Does the camera only truck right in the scene?",
+        "Does the camera only truck rightward?",
+        "Does the camera only truck from left to right?",
+        "Is the camera movement purely rightward?",
+        "Is this exclusively a rightward tracking shot?"
+    ],
+    "alt_question": [
+        "Is the camera only moving right (no panning or other movements)?",
+        "Does the shot feature only rightward camera movement?",
+        "Is the camera only traveling right in the scene?",
+        "Is this just a rightward tracking shot?",
+        "Is this strictly a right trucking motion?",
+        "Is the camera only translating to the right?",
+        "Does the camera only move physically from left to right?",
+        "Is this just a lateral movement to the right?",
+        "Does the camera only dolly right?",
+        "Is this purely a rightward dolly shot?",
+        "Is the camera only sliding right?",
+        "Is this exclusively a right trucking shot?"
+    ],
+    "def_prompt": [
+        "A shot where the camera only moves right.",
+        "A shot where the camera only moves rightward.",
+        "A shot where the camera only moves from left to right.",
+        "A shot where the camera only trucks right.",
+        "A shot where the camera only trucks rightward.",
+        "A shot where the camera only trucks from left to right.",
+        "The camera only moves rightward.",
+        "The camera only trucks right in the scene.",
+        "A video featuring exclusively rightward camera movement."
+    ],
+    "alt_prompt": [
+        "A scene where the camera only moves right (no panning or other movements).",
+        "A shot with pure rightward camera motion (moving sideways only).",
+        "A video where the camera only travels right.",
+        "A scene featuring only rightward tracking movement.",
+        "A shot where the camera only trucks right.",
+        "A video demonstrating pure rightward camera translation.",
+        "A scene where the camera only moves physically from left to right.",
+        "A shot with only lateral rightward movement.",
+        "A video where the camera only dollies right.",
+        "A scene with pure rightward tracking motion.",
+        "A shot where the camera only slides right.",
+        "A video featuring only right trucking movement."
+    ],
+    "pos_rule_str": "self.cam_motion.right is True and self.cam_motion.check_if_no_motion_cam(exclude=['right'])",
+    "neg_rule_str": "self.cam_motion.right is False or not self.cam_motion.check_if_no_motion_cam(exclude=['right']))",
+    "easy_neg_rule_str": {
+        "moving_left": "self.cam_motion.left is True",
+        "only_moving_left": "self.cam_motion.left is True and self.cam_motion.check_if_no_motion_cam(exclude=['left'])"
+    },
+    "hard_neg_rule_str": {
+        "panning_right": "self.cam_motion.pan_right is True and self.cam_motion.right is False",
+        "compound_motion_with_right": "self.cam_motion.right is True and not self.cam_motion.check_if_no_motion_cam(exclude=['right'])"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/roll_clockwise/has_roll_clockwise.json
+++ b/labels/cam_motion/camera_centric_movement/roll_clockwise/has_roll_clockwise.json
@@ -1,0 +1,58 @@
+{
+    "label": "Has Clockwise Roll Movement",
+    "label_name": "has_roll_clockwise",
+    "def_question": [
+        "Does the camera roll clockwise in the scene?",
+        "Does the camera rotate clockwise around its optical axis?",
+        "Is there a clockwise Dutch roll in the shot?",
+        "Does the camera perform a clockwise barrel roll?",
+        "Is the camera rolling clockwise relative to the horizon?",
+        "Does the horizon rotate clockwise in the shot?",
+        "Is there a clockwise Dutch angle movement?"
+    ],
+    "alt_question": [
+        "Does the camera spin clockwise along its forward axis?",
+        "Is there a clockwise canted angle movement?",
+        "Does the frame rotate clockwise while keeping the subject centered?",
+        "Is the camera executing a clockwise roll motion?",
+        "Does the shot feature a clockwise rotational movement around the lens axis?",
+        "Is there a clockwise spinning motion of the frame?",
+        "Does the camera twist clockwise in the scene?",
+        "Is this a clockwise Dutch roll shot?",
+        "Does the camera create a clockwise rotating horizon effect?",
+        "Is there a clockwise angular rotation of the frame?",
+        "Does the shot employ a clockwise rolling technique?",
+        "Is the camera performing a clockwise rotational movement?"
+    ],
+    "def_prompt": [
+        "A shot where the camera rolls clockwise.",
+        "A shot featuring a clockwise Dutch roll.",
+        "A scene with clockwise camera rotation around its optical axis.",
+        "The camera performs a clockwise barrel roll.",
+        "A video showing clockwise rotation relative to the horizon.",
+        "A shot with clockwise Dutch angle movement.",
+        "The camera executes a clockwise roll motion."
+    ],
+    "alt_prompt": [
+        "A scene where the camera spins clockwise along its forward axis.",
+        "A shot demonstrating clockwise canted angle movement.",
+        "A video where the frame rotates clockwise around the center.",
+        "A scene featuring clockwise Dutch roll technique.",
+        "A shot where the horizon rotates clockwise.",
+        "A video showing clockwise angular rotation of the frame.",
+        "A scene with clockwise barrel roll movement.",
+        "A shot employing clockwise Dutch angle technique.",
+        "A video demonstrating clockwise rotational movement around the lens axis.",
+        "A scene where the camera twists clockwise.",
+        "A shot with clockwise spinning motion of the frame.",
+        "A video featuring clockwise roll movement."
+    ],
+    "pos_rule_str": "self.cam_motion.roll_cw is True",
+    "neg_rule_str": "self.cam_motion.roll_cw is False",
+    "easy_neg_rule_str": {
+        "rolling_counterclockwise": "self.cam_motion.roll_ccw is True"
+    },
+    "hard_neg_rule_str": {
+        "panning_rotation": "self.cam_motion.pan_right is True or self.cam_motion.pan_left is True"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/roll_clockwise/only_roll_clockwise.json
+++ b/labels/cam_motion/camera_centric_movement/roll_clockwise/only_roll_clockwise.json
@@ -1,0 +1,60 @@
+{
+    "label": "Only Clockwise Roll Movement",
+    "label_name": "only_roll_clockwise",
+    "def_question": [
+        "Does the camera only roll clockwise in the scene?",
+        "Does the camera only rotate clockwise around its optical axis?",
+        "Is there only a clockwise Dutch roll in the shot?",
+        "Does the camera perform only a clockwise barrel roll?",
+        "Is the camera only rolling clockwise relative to the horizon?",
+        "Does the horizon only rotate clockwise in the shot?",
+        "Is there exclusively a clockwise Dutch angle movement?"
+    ],
+    "alt_question": [
+        "Is the camera only spinning clockwise along its forward axis?",
+        "Is there only a clockwise canted angle movement?",
+        "Does the frame only rotate clockwise while keeping the subject centered?",
+        "Is the camera executing only a clockwise roll motion?",
+        "Does the shot feature exclusively clockwise rotational movement around the lens axis?",
+        "Is there only a clockwise spinning motion of the frame?",
+        "Does the camera only twist clockwise in the scene?",
+        "Is this purely a clockwise Dutch roll shot?",
+        "Does the camera create only a clockwise rotating horizon effect?",
+        "Is there exclusively a clockwise angular rotation of the frame?",
+        "Does the shot employ only a clockwise rolling technique?",
+        "Is the camera performing exclusively clockwise rotational movement?"
+    ],
+    "def_prompt": [
+        "A shot where the camera only rolls clockwise.",
+        "A shot featuring only a clockwise Dutch roll.",
+        "A scene with only clockwise camera rotation around its optical axis.",
+        "The camera performs only a clockwise barrel roll.",
+        "A video showing only clockwise rotation relative to the horizon.",
+        "A shot with exclusively clockwise Dutch angle movement.",
+        "The camera executes only a clockwise roll motion."
+    ],
+    "alt_prompt": [
+        "A scene where the camera only spins clockwise along its forward axis.",
+        "A shot demonstrating purely clockwise canted angle movement.",
+        "A video where the frame only rotates clockwise around the center.",
+        "A scene featuring exclusively clockwise Dutch roll technique.",
+        "A shot where the horizon only rotates clockwise.",
+        "A video showing purely clockwise angular rotation of the frame.",
+        "A scene with only clockwise barrel roll movement.",
+        "A shot employing exclusively clockwise Dutch angle technique.",
+        "A video demonstrating only clockwise rotational movement around the lens axis.",
+        "A scene where the camera only twists clockwise.",
+        "A shot with purely clockwise spinning motion of the frame.",
+        "A video featuring exclusively clockwise roll movement."
+    ],
+    "pos_rule_str": "self.cam_motion.roll_cw is True and self.cam_motion.check_if_no_motion_cam(exclude=['roll_cw'])",
+    "neg_rule_str": "self.cam_motion.roll_cw is False or not self.cam_motion.check_if_no_motion_cam(exclude=['roll_cw']))",
+    "easy_neg_rule_str": {
+        "rolling_counterclockwise": "self.cam_motion.roll_ccw is True",
+        "only_rolling_counterclockwise": "self.cam_motion.roll_ccw is True and self.cam_motion.check_if_no_motion_cam(exclude=['roll_ccw'])"
+    },
+    "hard_neg_rule_str": {
+        "panning_rotation": "self.cam_motion.pan_right is True or self.cam_motion.pan_left is True",
+        "compound_motion_with_roll_cw": "self.cam_motion.roll_cw is True and not self.cam_motion.check_if_no_motion_cam(exclude=['roll_cw'])"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/roll_counterclockwise/has_roll_counterclockwise.json
+++ b/labels/cam_motion/camera_centric_movement/roll_counterclockwise/has_roll_counterclockwise.json
@@ -1,0 +1,58 @@
+{
+    "label": "Has Counterclockwise Roll Movement",
+    "label_name": "has_roll_counterclockwise",
+    "def_question": [
+        "Does the camera roll counterclockwise in the scene?",
+        "Does the camera rotate counterclockwise around its optical axis?",
+        "Is there a counterclockwise Dutch roll in the shot?",
+        "Does the camera perform a counterclockwise barrel roll?",
+        "Is the camera rolling counterclockwise relative to the horizon?",
+        "Does the horizon rotate counterclockwise in the shot?",
+        "Is there a counterclockwise Dutch angle movement?"
+    ],
+    "alt_question": [
+        "Does the camera spin counterclockwise along its forward axis?",
+        "Is there a counterclockwise canted angle movement?",
+        "Does the frame rotate counterclockwise while keeping the subject centered?",
+        "Is the camera executing a counterclockwise roll motion?",
+        "Does the shot feature a counterclockwise rotational movement around the lens axis?",
+        "Is there a counterclockwise spinning motion of the frame?",
+        "Does the camera twist counterclockwise in the scene?",
+        "Is this a counterclockwise Dutch roll shot?",
+        "Does the camera create a counterclockwise rotating horizon effect?",
+        "Is there a counterclockwise angular rotation of the frame?",
+        "Does the shot employ a counterclockwise rolling technique?",
+        "Is the camera performing a counterclockwise rotational movement?"
+    ],
+    "def_prompt": [
+        "A shot where the camera rolls counterclockwise.",
+        "A shot featuring a counterclockwise Dutch roll.",
+        "A scene with counterclockwise camera rotation around its optical axis.",
+        "The camera performs a counterclockwise barrel roll.",
+        "A video showing counterclockwise rotation relative to the horizon.",
+        "A shot with counterclockwise Dutch angle movement.",
+        "The camera executes a counterclockwise roll motion."
+    ],
+    "alt_prompt": [
+        "A scene where the camera spins counterclockwise along its forward axis.",
+        "A shot demonstrating counterclockwise canted angle movement.",
+        "A video where the frame rotates counterclockwise around the center.",
+        "A scene featuring counterclockwise Dutch roll technique.",
+        "A shot where the horizon rotates counterclockwise.",
+        "A video showing counterclockwise angular rotation of the frame.",
+        "A scene with counterclockwise barrel roll movement.",
+        "A shot employing counterclockwise Dutch angle technique.",
+        "A video demonstrating counterclockwise rotational movement around the lens axis.",
+        "A scene where the camera twists counterclockwise.",
+        "A shot with counterclockwise spinning motion of the frame.",
+        "A video featuring counterclockwise roll movement."
+    ],
+    "pos_rule_str": "self.cam_motion.roll_ccw is True",
+    "neg_rule_str": "self.cam_motion.roll_ccw is False",
+    "easy_neg_rule_str": {
+        "rolling_clockwise": "self.cam_motion.roll_cw is True"
+    },
+    "hard_neg_rule_str": {
+        "panning_rotation": "self.cam_motion.pan_right is True or self.cam_motion.pan_left is True"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/roll_counterclockwise/only_roll_counterclockwise.json
+++ b/labels/cam_motion/camera_centric_movement/roll_counterclockwise/only_roll_counterclockwise.json
@@ -1,0 +1,60 @@
+{
+    "label": "Only Counterclockwise Roll Movement",
+    "label_name": "only_roll_counterclockwise",
+    "def_question": [
+        "Does the camera only roll counterclockwise in the scene?",
+        "Does the camera only rotate counterclockwise around its optical axis?",
+        "Is there only a counterclockwise Dutch roll in the shot?",
+        "Does the camera perform only a counterclockwise barrel roll?",
+        "Is the camera only rolling counterclockwise relative to the horizon?",
+        "Does the horizon only rotate counterclockwise in the shot?",
+        "Is there exclusively a counterclockwise Dutch angle movement?"
+    ],
+    "alt_question": [
+        "Is the camera only spinning counterclockwise along its forward axis?",
+        "Is there only a counterclockwise canted angle movement?",
+        "Does the frame only rotate counterclockwise while keeping the subject centered?",
+        "Is the camera executing only a counterclockwise roll motion?",
+        "Does the shot feature exclusively counterclockwise rotational movement around the lens axis?",
+        "Is there only a counterclockwise spinning motion of the frame?",
+        "Does the camera only twist counterclockwise in the scene?",
+        "Is this purely a counterclockwise Dutch roll shot?",
+        "Does the camera create only a counterclockwise rotating horizon effect?",
+        "Is there exclusively a counterclockwise angular rotation of the frame?",
+        "Does the shot employ only a counterclockwise rolling technique?",
+        "Is the camera performing exclusively counterclockwise rotational movement?"
+    ],
+    "def_prompt": [
+        "A shot where the camera only rolls counterclockwise.",
+        "A shot featuring only a counterclockwise Dutch roll.",
+        "A scene with only counterclockwise camera rotation around its optical axis.",
+        "The camera performs only a counterclockwise barrel roll.",
+        "A video showing only counterclockwise rotation relative to the horizon.",
+        "A shot with exclusively counterclockwise Dutch angle movement.",
+        "The camera executes only a counterclockwise roll motion."
+    ],
+    "alt_prompt": [
+        "A scene where the camera only spins counterclockwise along its forward axis.",
+        "A shot demonstrating purely counterclockwise canted angle movement.",
+        "A video where the frame only rotates counterclockwise around the center.",
+        "A scene featuring exclusively counterclockwise Dutch roll technique.",
+        "A shot where the horizon only rotates counterclockwise.",
+        "A video showing purely counterclockwise angular rotation of the frame.",
+        "A scene with only counterclockwise barrel roll movement.",
+        "A shot employing exclusively counterclockwise Dutch angle technique.",
+        "A video demonstrating only counterclockwise rotational movement around the lens axis.",
+        "A scene where the camera only twists counterclockwise.",
+        "A shot with purely counterclockwise spinning motion of the frame.",
+        "A video featuring exclusively counterclockwise roll movement."
+    ],
+    "pos_rule_str": "self.cam_motion.roll_ccw is True and self.cam_motion.check_if_no_motion_cam(exclude=['roll_ccw'])",
+    "neg_rule_str": "self.cam_motion.roll_ccw is False or not self.cam_motion.check_if_no_motion_cam(exclude=['roll_ccw']))",
+    "easy_neg_rule_str": {
+        "rolling_clockwise": "self.cam_motion.roll_cw is True",
+        "only_rolling_clockwise": "self.cam_motion.roll_cw is True and self.cam_motion.check_if_no_motion_cam(exclude=['roll_cw'])"
+    },
+    "hard_neg_rule_str": {
+        "panning_rotation": "self.cam_motion.pan_right is True or self.cam_motion.pan_left is True",
+        "compound_motion_with_roll_ccw": "self.cam_motion.roll_ccw is True and not self.cam_motion.check_if_no_motion_cam(exclude=['roll_ccw'])"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/tilt_down/only_tilt_down.json
+++ b/labels/cam_motion/camera_centric_movement/tilt_down/only_tilt_down.json
@@ -1,0 +1,63 @@
+{
+    "label": "Only Tilt Down Movement",
+    "label_name": "only_tilt_down",
+    "def_question": [
+        "Does the camera only tilt down in the scene?",
+        "Does the camera only tilt downward in the scene, without any other camera movements?",
+        "Does the camera only tilt downward?",
+        "Is this a downward tilting shot?",
+        "Is the camera only tilting downward?",
+        "Is the camera movement purely a downward tilt?",
+        "Is this exclusively a downward tilting shot?",
+        "Does the camera only execute a tilt movement downward?",
+        "Is this purely a downward tilting motion (no pedestal or other movements)?",
+        "Does the shot feature only a camera tilt downward (rotating, not moving down)?",
+        "Is the camera only rotating downward on its horizontal axis (no pedestal or other movements)?"
+    ],
+    "alt_question": [
+        "Does the camera only tilt from top to bottom?",
+        "Is the camera only tilting from top to bottom?",
+        "Is the camera only rotating downward?",
+        "Does the camera just angle downward?",
+        "Is the movement limited to a downward rotation?",
+        "Is this just a downward sweep of the camera?",
+        "Is the camera only pivoting down?",
+        "Is this strictly a vertical movement from top to bottom?",
+        "Does the camera only move vertically from top to bottom?"
+    ],
+    "def_prompt": [
+        "A shot where the camera only tilts down.",
+        "A shot where the camera only tilts downward.",
+        "A shot where the camera only tilts from top to bottom.",
+        "The camera only tilts downward.",
+        "The camera only tilts down in the scene.",
+        "The camera only tilts from top to bottom.",
+        "A scene where the camera tilts down only (not pedestals/moves down).",
+        "A video with pure downward tilting motion (rotating only, no translation).",
+        "A shot with a downward tilting motion (camera rotating, not moving down).",
+        "A video where the camera only rotates downward on its horizontal axis.",
+        "A shot demonstrating exclusively downward tilting motion (no pedestal movement)."
+    ],
+    "alt_prompt": [
+        "A video featuring exclusively downward tilting movement.",
+        "A scene with only a downward tilting motion (no pedestal or other movements).",
+        "A shot containing only a downward tilt (camera rotating, not moving down).",
+        "A scene with nothing but a downward tilting camera movement (no vertical movement).",
+        "A scene where the camera only rotates downward.",
+        "A shot with just a downward turning motion.",
+        "A video showing only a downward sweeping movement.",
+        "A scene limited to downward camera rotation.",
+        "A shot where the camera just pivots down.",
+        "A scene with just vertical camera rotation from top to bottom."
+    ],
+    "pos_rule_str": "self.cam_motion.tilt_down is True and self.cam_motion.check_if_no_motion_cam(exclude=['tilt_down'])",
+    "neg_rule_str": "self.cam_motion.tilt_down is False or not self.cam_motion.check_if_no_motion_cam(exclude=['tilt_down']))",
+    "easy_neg_rule_str": {
+        "tilting_up": "self.cam_motion.tilt_up is True",
+        "only_tilting_up": "self.cam_motion.tilt_up is True and self.cam_motion.check_if_no_motion_cam(exclude=['tilt_up'])"
+    },
+    "hard_neg_rule_str": {
+        "moving_down": "self.cam_motion.down is True and self.cam_motion.tilt_down is False",
+        "compound_motion_with_tilt_down": "self.cam_motion.tilt_down is True and not self.cam_motion.check_if_no_motion_cam(exclude=['tilt_down'])"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/tilt_up/has_tilt_up.json
+++ b/labels/cam_motion/camera_centric_movement/tilt_up/has_tilt_up.json
@@ -1,0 +1,57 @@
+{
+    "label": "Has Tilt Up Movement",
+    "label_name": "has_tilt_up",
+    "def_question": [
+        "Does the camera tilt up in the scene?",
+        "Does the camera tilt upward in the scene?",
+        "Does the camera tilt upward?",
+        "Does the camera execute a tilt movement upward?",
+        "Is the camera tilting up in the scene?",
+        "Is the camera tilting upward?"
+    ],
+    "alt_question": [
+        "Does the camera tilt from bottom to top?",
+        "Is the camera tilting from bottom to top?",
+        "Does the camera tilt up (not pedestal up)?",
+        "Does the shot feature a camera tilt upward (not a pedestal movement)?",
+        "Is the camera tilting upward (not pedestaling up)?",
+        "Is this an upward tilting shot?",
+        "Is this an up tilting motion (not moving up)?",
+        "Is the camera rotating upward on its horizontal axis?",
+        "Does the view shift from bottom to top?",
+        "Is the camera angling upward?",
+        "Does the camera sweep upward?",
+        "Is the camera pivoting up?",
+        "Does the camera rotate vertically upward?",
+        "Is this a vertical rotation of the camera upward?"
+    ],
+    "def_prompt": [
+        "A shot where the camera tilts up.",
+        "A shot where the camera tilts upward.",
+        "The camera tilts upward.",
+        "The camera tilts up in the scene.",
+        "A video where the camera angles upward.",
+        "A video featuring an upward tilting movement.",
+        "A scene featuring an upward tilting camera movement."
+    ],
+    "alt_prompt": [
+        "A shot where the camera tilts from bottom to top.",
+        "The camera tilts from bottom to top.",
+        "A scene where the camera tilts up (not pedestals up).",
+        "A shot with an upward tilting motion (not a pedestal movement).",
+        "A scene where the camera rotates upward.",
+        "A shot where the view shifts from bottom to top.",
+        "A scene where the camera sweeps upward.",
+        "A shot with upward camera rotation.",
+        "A video where the camera pivots up.",
+        "A scene where the camera rotates vertically upward."
+    ],
+    "pos_rule_str": "self.cam_motion.tilt_up is True",
+    "neg_rule_str": "self.cam_motion.tilt_up is False",
+    "easy_neg_rule_str": {
+        "tilting_down": "self.cam_motion.tilt_down is True"
+    },
+    "hard_neg_rule_str": {
+        "moving_up": "self.cam_motion.up is True and self.cam_motion.tilt_up is False"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/tilt_up/only_tilt_up.json
+++ b/labels/cam_motion/camera_centric_movement/tilt_up/only_tilt_up.json
@@ -1,0 +1,63 @@
+{
+    "label": "Only Tilt Up Movement",
+    "label_name": "only_tilt_up",
+    "def_question": [
+        "Does the camera only tilt up in the scene?",
+        "Does the camera only tilt upward in the scene, without any other camera movements?",
+        "Does the camera only tilt upward?",
+        "Is this an upward tilting shot?",
+        "Is the camera only tilting upward?",
+        "Is the camera movement purely an upward tilt?",
+        "Is this exclusively an upward tilting shot?",
+        "Does the camera only execute a tilt movement upward?",
+        "Is this purely an upward tilting motion (no pedestal or other movements)?",
+        "Does the shot feature only a camera tilt upward (rotating, not moving up)?",
+        "Is the camera only rotating upward on its horizontal axis (no pedestal or other movements)?"
+    ],
+    "alt_question": [
+        "Does the camera only tilt from bottom to top?",
+        "Is the camera only tilting from bottom to top?",
+        "Is the camera only rotating upward?",
+        "Does the camera just angle upward?",
+        "Is the movement limited to an upward rotation?",
+        "Is this just an upward sweep of the camera?",
+        "Is the camera only pivoting up?",
+        "Is this strictly a vertical movement from bottom to top?",
+        "Does the camera only move vertically from bottom to top?"
+    ],
+    "def_prompt": [
+        "A shot where the camera only tilts up.",
+        "A shot where the camera only tilts upward.",
+        "A shot where the camera only tilts from bottom to top.",
+        "The camera only tilts upward.",
+        "The camera only tilts up in the scene.",
+        "The camera only tilts from bottom to top.",
+        "A scene where the camera tilts up only (not pedestals/moves up).",
+        "A video with pure upward tilting motion (rotating only, no translation).",
+        "A shot with an upward tilting motion (camera rotating, not moving up).",
+        "A video where the camera only rotates upward on its horizontal axis.",
+        "A shot demonstrating exclusively upward tilting motion (no pedestal movement)."
+    ],
+    "alt_prompt": [
+        "A video featuring exclusively upward tilting movement.",
+        "A scene with only an upward tilting motion (no pedestal or other movements).",
+        "A shot containing only an upward tilt (camera rotating, not moving up).",
+        "A scene with nothing but an upward tilting camera movement (no vertical movement).",
+        "A scene where the camera only rotates upward.",
+        "A shot with just an upward turning motion.",
+        "A video showing only an upward sweeping movement.",
+        "A scene limited to upward camera rotation.",
+        "A shot where the camera just pivots up.",
+        "A scene with just vertical camera rotation from bottom to top."
+    ],
+    "pos_rule_str": "self.cam_motion.tilt_up is True and self.cam_motion.check_if_no_motion_cam(exclude=['tilt_up'])",
+    "neg_rule_str": "self.cam_motion.tilt_up is False or not self.cam_motion.check_if_no_motion_cam(exclude=['tilt_up']))",
+    "easy_neg_rule_str": {
+        "tilting_down": "self.cam_motion.tilt_down is True",
+        "only_tilting_down": "self.cam_motion.tilt_down is True and self.cam_motion.check_if_no_motion_cam(exclude=['tilt_down'])"
+    },
+    "hard_neg_rule_str": {
+        "moving_up": "self.cam_motion.up is True and self.cam_motion.tilt_up is False",
+        "compound_motion_with_tilt_up": "self.cam_motion.tilt_up is True and not self.cam_motion.check_if_no_motion_cam(exclude=['tilt_up'])"
+    }
+}

--- a/labels/cam_motion/camera_centric_movement/upward/has_upward_wrt_camera.json
+++ b/labels/cam_motion/camera_centric_movement/upward/has_upward_wrt_camera.json
@@ -1,6 +1,6 @@
 {
     "label": "Has Upward Movement (Relative to Camera)",
-    "label_name": "has_up_wrt_camera",
+    "label_name": "has_upward_wrt_camera",
     "def_question": [
         "Does the camera move upward (not tilting up) with respect to the initial frame?",
         "Is the camera moving upward in space based on its starting position?",

--- a/labels/cam_motion/camera_centric_movement/upward/only_upward_wrt_camera.json
+++ b/labels/cam_motion/camera_centric_movement/upward/only_upward_wrt_camera.json
@@ -1,6 +1,6 @@
 {
     "label": "Only Upward Movement (Relative to Camera)",
-    "label_name": "only_up_wrt_camera",
+    "label_name": "only_upward_wrt_camera",
     "def_question": [
         "Does the camera only move upward (not tilting up) with respect to the initial frame?",
         "Is upward motion the only camera movement from the initial frame?",

--- a/labels/cam_motion/ground_centric_movement/downward/has_downward_wrt_ground.json
+++ b/labels/cam_motion/ground_centric_movement/downward/has_downward_wrt_ground.json
@@ -1,6 +1,6 @@
 {
     "label": "Has Downward Movement (Relative to Ground, Bird's/Worm's Eye Views Not Included)",
-    "label_name": "has_down_wrt_ground",
+    "label_name": "has_downward_wrt_ground",
     "def_question": [
         "Does the camera move downward (not tilting down) in the scene?",
         "Is the camera moving downward in the scene?",

--- a/labels/cam_motion/ground_centric_movement/downward/has_downward_wrt_ground_birds_worms_included.json
+++ b/labels/cam_motion/ground_centric_movement/downward/has_downward_wrt_ground_birds_worms_included.json
@@ -1,6 +1,6 @@
 {
     "label": "Has Downward Movement (Relative to Ground, Bird's/Worm's Eye Views Included)",
-    "label_name": "has_down_wrt_ground_birds_worms_included",
+    "label_name": "has_downward_wrt_ground_birds_worms_included",
     "def_question": [
         "Does the camera move downward (not tilting down) in the scene, or move west if it's a bird's eye view, or move east if it's a worm's eye view?",
         "Does the camera move downward (not tilting down) in the scene, or move left if it's a bird's eye view, or move right if it's a worm's eye view?",

--- a/labels/cam_motion/ground_centric_movement/downward/only_downward_wrt_ground.json
+++ b/labels/cam_motion/ground_centric_movement/downward/only_downward_wrt_ground.json
@@ -1,6 +1,6 @@
 {
     "label": "Only Downward Movement (Relative to Ground, Bird's/Worm's Eye Views Not Included)",
-    "label_name": "only_down_wrt_ground",
+    "label_name": "only_downward_wrt_ground",
     "def_question": [
         "Does the camera only move downward (not tilting down) with respect to the ground?",
         "Is the camera only moving downward with respect to the ground?",

--- a/labels/cam_motion/ground_centric_movement/downward/only_downward_wrt_ground_birds_worms_included.json
+++ b/labels/cam_motion/ground_centric_movement/downward/only_downward_wrt_ground_birds_worms_included.json
@@ -1,6 +1,6 @@
 {
     "label": "Only Downward Movement (Relative to Ground, Bird's/Worm's Eye Views Included)",
-    "label_name": "only_down_wrt_ground_birds_worms_included",
+    "label_name": "only_downward_wrt_ground_birds_worms_included",
     "def_question": [
         "Does the camera move only downward (not tilting down) in the scene, or only westward in a bird's eye view, or only eastward in a worm's eye view?",
         "Does the camera move only downward (not tilting down) in the scene, or only leftward in a bird's eye view, or only rightward in a worm's eye view?",

--- a/labels/cam_motion/ground_centric_movement/upward/has_upward_wrt_ground.json
+++ b/labels/cam_motion/ground_centric_movement/upward/has_upward_wrt_ground.json
@@ -1,6 +1,6 @@
 {
     "label": "Has Upward Movement (Relative to Ground, Bird's/Worm's Eye Views Not Included)",
-    "label_name": "has_up_wrt_ground",
+    "label_name": "has_upward_wrt_ground",
     "def_question": [
         "Does the camera move upward (not tilting up) in the scene?",
         "Is the camera moving upward in the scene?",

--- a/labels/cam_motion/ground_centric_movement/upward/has_upward_wrt_ground_birds_worms_included.json
+++ b/labels/cam_motion/ground_centric_movement/upward/has_upward_wrt_ground_birds_worms_included.json
@@ -1,6 +1,6 @@
 {
     "label": "Has Upward Movement (Relative to Ground, Bird's/Worm's Eye Views Included)",
-    "label_name": "has_up_wrt_ground_birds_worms_included",
+    "label_name": "has_upward_wrt_ground_birds_worms_included",
     "def_question": [
         "Does the camera move upward (not tilting up) in the scene, or move east if it's a bird's eye view, or move west if it's a worm's eye view?",
         "Does the camera move upward (not tilting up) in the scene, or move right if it's a bird's eye view, or move left if it's a worm's eye view?",

--- a/labels/cam_motion/ground_centric_movement/upward/only_upward_wrt_ground.json
+++ b/labels/cam_motion/ground_centric_movement/upward/only_upward_wrt_ground.json
@@ -1,6 +1,6 @@
 {
     "label": "Only Upward Movement (Relative to Ground, Bird's/Worm's Eye Views Not Included)",
-    "label_name": "only_up_wrt_ground",
+    "label_name": "only_upward_wrt_ground",
     "def_question": [
         "Does the camera only move upward (not tilting up) with respect to the ground?",
         "Is the camera only moving upward with respect to the ground?",

--- a/labels/cam_motion/ground_centric_movement/upward/only_upward_wrt_ground_birds_worms_included.json
+++ b/labels/cam_motion/ground_centric_movement/upward/only_upward_wrt_ground_birds_worms_included.json
@@ -1,6 +1,6 @@
 {
     "label": "Only Upward Movement (Relative to Ground, Bird's/Worm's Eye Views Included)",
-    "label_name": "only_up_wrt_ground_birds_worms_included",
+    "label_name": "only_upward_wrt_ground_birds_worms_included",
     "def_question": [
         "Does the camera move only upward (not tilting up) in the scene, or only eastward in a bird's eye view, or only westward in a worm's eye view?",
         "Does the camera move only upward (not tilting up) in the scene, or only rightward in a bird's eye view, or only leftward in a worm's eye view?",


### PR DESCRIPTION
## Changes

### Folder Renames
- Renamed `up` → `upward` and `down` → `downward` in both camera_centric and ground_centric movements
- Updated all JSON filenames to use upward/downward consistently
- Updated `label_name` fields in all JSON files to match new naming convention

### New Motion Types Added
- `leftward` and `rightward` for lateral camera movements
- `roll_clockwise` and `roll_counterclockwise` for Dutch angle movements
- `tilt_up` folder with corresponding JSON files
- Added `only_tilt_down.json` to complete the tilt_down folder

All new files follow the established pattern with both `has_` and `only_` variants, maintaining consistency with existing motion types.