### PR TITLE
Update shot size questions and prompts to be more consistent

### DIFF
--- a/labels/cam_setup/shot_size/start_with/shot_size_start_with_extreme_close_up.json
+++ b/labels/cam_setup/shot_size/start_with/shot_size_start_with_extreme_close_up.json
@@ -2,30 +2,23 @@
     "label": "Shot Size Start With Extreme Close Up",
     "label_name": "shot_size_start_with_extreme_close_up",
     "def_question": [
-        "Does the video start with extreme close up?"
+        "Does the video begin with an extreme close-up shot?"
     ],
     "alt_question": [
-        "Does the shot start with extreme close up?",
-        "Is the starting frame showing extreme close up?",
-        "Does the video start using extreme close up?",
-        "Is the initial shot at extreme close up?",
-        "Does the sequence start with extreme close up?",
-        "Is the first shot at extreme close up?",
-        "Does the video open with extreme close up?",
-        "Is the starting frame at extreme close up?"
+        "Does the video open with an extreme close-up?",
+        "Is the first shot of the video an extreme close-up?",
+        "Does the video start with a tightly framed extreme close-up?",
+        "Is the opening shot of the video an extreme close-up?"
     ],
     "def_prompt": [
-        "A video that starts with extreme close up."
+        "A video that starts with an extreme close-up shot."
     ],
     "alt_prompt": [
-        "A shot starting with extreme close up.",
-        "A video starting at extreme close up.",
-        "A sequence beginning with extreme close up.",
-        "A shot initially at extreme close up.",
-        "A video opening with extreme close up.",
-        "A shot starting at extreme close up.",
-        "A video beginning with extreme close up.",
-        "A sequence starting at extreme close up."
+        "The video begins with an extreme close-up shot.",
+        "The video opens with an extreme close-up.",
+        "The first shot of the video is an extreme close-up.",
+        "The video starts with a tightly framed extreme close-up.",
+        "The opening shot of the video is an extreme close-up."
     ],
     "pos_rule_str": "self.shot_size_info['start'] == 'extreme_close_up'",
     "neg_rule_str": "self.shot_size_info['start'] not in ['extreme_close_up', 'unknown']",

--- a/labels/cam_setup/shot_size/start_with/shot_size_start_with_extreme_wide.json
+++ b/labels/cam_setup/shot_size/start_with/shot_size_start_with_extreme_wide.json
@@ -2,30 +2,23 @@
     "label": "Shot Size Start With Extreme Wide",
     "label_name": "shot_size_start_with_extreme_wide",
     "def_question": [
-        "Does the video start with extreme wide?"
+        "Does the video begin with an extreme wide shot?"
     ],
     "alt_question": [
-        "Does the shot start with extreme wide?",
-        "Is the starting frame showing extreme wide?",
-        "Does the video start using extreme wide?",
-        "Is the initial shot at extreme wide?",
-        "Does the sequence start with extreme wide?",
-        "Is the first shot at extreme wide?",
-        "Does the video open with extreme wide?",
-        "Is the starting frame at extreme wide?"
+        "Does the video open with an extreme wide shot?",
+        "Is the first shot of the video an extreme wide shot?",
+        "Does the video start with a tightly framed extreme wide shot?",
+        "Is the opening shot of the video an extreme wide shot?"
     ],
     "def_prompt": [
-        "A video that starts with extreme wide."
+        "A video that starts with an extreme wide shot."
     ],
     "alt_prompt": [
-        "A shot starting with extreme wide.",
-        "A video starting at extreme wide.",
-        "A sequence beginning with extreme wide.",
-        "A shot initially at extreme wide.",
-        "A video opening with extreme wide.",
-        "A shot starting at extreme wide.",
-        "A video beginning with extreme wide.",
-        "A sequence starting at extreme wide."
+        "The video begins with an extreme wide shot.",
+        "The video opens with an extreme wide shot.",
+        "The first shot of the video is an extreme wide shot.",
+        "The video starts with a tightly framed extreme wide shot.",
+        "The opening shot of the video is an extreme wide shot."
     ],
     "pos_rule_str": "self.shot_size_info['start'] == 'extreme_wide'",
     "neg_rule_str": "self.shot_size_info['start'] not in ['extreme_wide', 'unknown']",

--- a/labels/cam_setup/shot_size/start_with/shot_size_start_with_full.json
+++ b/labels/cam_setup/shot_size/start_with/shot_size_start_with_full.json
@@ -2,30 +2,23 @@
     "label": "Shot Size Start With Full",
     "label_name": "shot_size_start_with_full",
     "def_question": [
-        "Does the video start with full?"
+        "Does the video begin with a full shot?"
     ],
     "alt_question": [
-        "Does the shot start with full?",
-        "Is the starting frame showing full?",
-        "Does the video start using full?",
-        "Is the initial shot at full?",
-        "Does the sequence start with full?",
-        "Is the first shot at full?",
-        "Does the video open with full?",
-        "Is the starting frame at full?"
+        "Does the video open with a full shot?",
+        "Is the first shot of the video a full shot?",
+        "Does the video start with a tightly framed full shot?",
+        "Is the opening shot of the video a full shot?"
     ],
     "def_prompt": [
-        "A video that starts with full."
+        "A video that starts with a full shot."
     ],
     "alt_prompt": [
-        "A shot starting with full.",
-        "A video starting at full.",
-        "A sequence beginning with full.",
-        "A shot initially at full.",
-        "A video opening with full.",
-        "A shot starting at full.",
-        "A video beginning with full.",
-        "A sequence starting at full."
+        "The video begins with a full shot.",
+        "The video opens with a full shot.",
+        "The first shot of the video is a full shot.",
+        "The video starts with a tightly framed full shot.",
+        "The opening shot of the video is a full shot."
     ],
     "pos_rule_str": "self.shot_size_info['start'] == 'full'",
     "neg_rule_str": "self.shot_size_info['start'] not in ['full', 'unknown']",

--- a/labels/cam_setup/shot_size/start_with/shot_size_start_with_medium.json
+++ b/labels/cam_setup/shot_size/start_with/shot_size_start_with_medium.json
@@ -2,30 +2,23 @@
     "label": "Shot Size Start With Medium",
     "label_name": "shot_size_start_with_medium",
     "def_question": [
-        "Does the video start with medium?"
+        "Does the video begin with a medium shot?"
     ],
     "alt_question": [
-        "Does the shot start with medium?",
-        "Is the starting frame showing medium?",
-        "Does the video start using medium?",
-        "Is the initial shot at medium?",
-        "Does the sequence start with medium?",
-        "Is the first shot at medium?",
-        "Does the video open with medium?",
-        "Is the starting frame at medium?"
+        "Does the video open with a medium shot?",
+        "Is the first shot of the video a medium shot?",
+        "Does the video start with a tightly framed medium shot?",
+        "Is the opening shot of the video a medium shot?"
     ],
     "def_prompt": [
-        "A video that starts with medium."
+        "A video that starts with a medium shot."
     ],
     "alt_prompt": [
-        "A shot starting with medium.",
-        "A video starting at medium.",
-        "A sequence beginning with medium.",
-        "A shot initially at medium.",
-        "A video opening with medium.",
-        "A shot starting at medium.",
-        "A video beginning with medium.",
-        "A sequence starting at medium."
+        "The video begins with a medium shot.",
+        "The video opens with a medium shot.",
+        "The first shot of the video is a medium shot.",
+        "The video starts with a tightly framed medium shot.",
+        "The opening shot of the video is a medium shot."
     ],
     "pos_rule_str": "self.shot_size_info['start'] == 'medium'",
     "neg_rule_str": "self.shot_size_info['start'] not in ['medium', 'unknown']",

--- a/labels/cam_setup/shot_size/start_with/shot_size_start_with_medium_close_up.json
+++ b/labels/cam_setup/shot_size/start_with/shot_size_start_with_medium_close_up.json
@@ -2,30 +2,23 @@
     "label": "Shot Size Start With Medium Close Up",
     "label_name": "shot_size_start_with_medium_close_up",
     "def_question": [
-        "Does the video start with medium close up?"
+        "Does the video begin with a medium close-up shot?"
     ],
     "alt_question": [
-        "Does the shot start with medium close up?",
-        "Is the starting frame showing medium close up?",
-        "Does the video start using medium close up?",
-        "Is the initial shot at medium close up?",
-        "Does the sequence start with medium close up?",
-        "Is the first shot at medium close up?",
-        "Does the video open with medium close up?",
-        "Is the starting frame at medium close up?"
+        "Does the video open with a medium close-up?",
+        "Is the first shot of the video a medium close-up?",
+        "Does the video start with a tightly framed medium close-up?",
+        "Is the opening shot of the video a medium close-up?"
     ],
     "def_prompt": [
-        "A video that starts with medium close up."
+        "A video that starts with a medium close-up shot."
     ],
     "alt_prompt": [
-        "A shot starting with medium close up.",
-        "A video starting at medium close up.",
-        "A sequence beginning with medium close up.",
-        "A shot initially at medium close up.",
-        "A video opening with medium close up.",
-        "A shot starting at medium close up.",
-        "A video beginning with medium close up.",
-        "A sequence starting at medium close up."
+        "The video begins with a medium close-up shot.",
+        "The video opens with a medium close-up.",
+        "The first shot of the video is a medium close-up.",
+        "The video starts with a tightly framed medium close-up.",
+        "The opening shot of the video is a medium close-up."
     ],
     "pos_rule_str": "self.shot_size_info['start'] == 'medium_close_up'",
     "neg_rule_str": "self.shot_size_info['start'] not in ['medium_close_up', 'unknown']",

--- a/labels/cam_setup/shot_size/start_with/shot_size_start_with_medium_full.json
+++ b/labels/cam_setup/shot_size/start_with/shot_size_start_with_medium_full.json
@@ -2,30 +2,23 @@
     "label": "Shot Size Start With Medium Full",
     "label_name": "shot_size_start_with_medium_full",
     "def_question": [
-        "Does the video start with medium full?"
+        "Does the video begin with a medium full shot?"
     ],
     "alt_question": [
-        "Does the shot start with medium full?",
-        "Is the starting frame showing medium full?",
-        "Does the video start using medium full?",
-        "Is the initial shot at medium full?",
-        "Does the sequence start with medium full?",
-        "Is the first shot at medium full?",
-        "Does the video open with medium full?",
-        "Is the starting frame at medium full?"
+        "Does the video open with a medium full shot?",
+        "Is the first shot of the video a medium full shot?",
+        "Does the video start with a tightly framed medium full shot?",
+        "Is the opening shot of the video a medium full shot?"
     ],
     "def_prompt": [
-        "A video that starts with medium full."
+        "A video that starts with a medium full shot."
     ],
     "alt_prompt": [
-        "A shot starting with medium full.",
-        "A video starting at medium full.",
-        "A sequence beginning with medium full.",
-        "A shot initially at medium full.",
-        "A video opening with medium full.",
-        "A shot starting at medium full.",
-        "A video beginning with medium full.",
-        "A sequence starting at medium full."
+        "The video begins with a medium full shot.",
+        "The video opens with a medium full shot.",
+        "The first shot of the video is a medium full shot.",
+        "The video starts with a tightly framed medium full shot.",
+        "The opening shot of the video is a medium full shot."
     ],
     "pos_rule_str": "self.shot_size_info['start'] == 'medium_full'",
     "neg_rule_str": "self.shot_size_info['start'] not in ['medium_full', 'unknown']",

--- a/labels/cam_setup/shot_size/start_with/shot_size_start_with_wide.json
+++ b/labels/cam_setup/shot_size/start_with/shot_size_start_with_wide.json
@@ -2,30 +2,23 @@
     "label": "Shot Size Start With Wide",
     "label_name": "shot_size_start_with_wide",
     "def_question": [
-        "Does the video start with wide?"
+        "Does the video begin with a wide shot?"
     ],
     "alt_question": [
-        "Does the shot start with wide?",
-        "Is the starting frame showing wide?",
-        "Does the video start using wide?",
-        "Is the initial shot at wide?",
-        "Does the sequence start with wide?",
-        "Is the first shot at wide?",
-        "Does the video open with wide?",
-        "Is the starting frame at wide?"
+        "Does the video open with a wide shot?",
+        "Is the first shot of the video a wide shot?",
+        "Does the video start with a tightly framed wide shot?",
+        "Is the opening shot of the video a wide shot?"
     ],
     "def_prompt": [
-        "A video that starts with wide."
+        "A video that starts with a wide shot."
     ],
     "alt_prompt": [
-        "A shot starting with wide.",
-        "A video starting at wide.",
-        "A sequence beginning with wide.",
-        "A shot initially at wide.",
-        "A video opening with wide.",
-        "A shot starting at wide.",
-        "A video beginning with wide.",
-        "A sequence starting at wide."
+        "The video begins with a wide shot.",
+        "The video opens with a wide shot.",
+        "The first shot of the video is a wide shot.",
+        "The video starts with a tightly framed wide shot.",
+        "The opening shot of the video is a wide shot."
     ],
     "pos_rule_str": "self.shot_size_info['start'] == 'wide'",
     "neg_rule_str": "self.shot_size_info['start'] not in ['wide', 'unknown']",


### PR DESCRIPTION
This PR updates the questions and prompts in all shot size files under `labels/cam_setup/shot_size/start_with/` to be more consistent. Changes include:

- Updated def_question to use consistent pattern "Does the video begin with a [shot_size] shot?"
- Reduced alt_questions to 4 consistent patterns
- Updated def_prompt to use consistent pattern "A video that starts with a [shot_size] shot."
- Updated alt_prompts to use 5 consistent patterns
- Improved grammar with proper articles (a/an)
- Maintained consistent hyphenation for compound terms