### PR TITLE
Add shot size is_always label files

### DIFF
--- a/labels/cam_setup/shot_size/is_always/shot_size_is_close_up.json
+++ b/labels/cam_setup/shot_size/is_always/shot_size_is_close_up.json
@@ -1,0 +1,36 @@
+{
+    "label": "Shot Size Is Close Up",
+    "label_name": "shot_size_is_close_up",
+    "def_question": [
+        "Does the video maintain a close-up shot throughout, consistently highlighting a distinct part of the subject while maintaining context?"
+    ],
+    "alt_question": [
+        "Is the entire video filmed in close-up, focusing on the subject's prominent features?",
+        "Does the shot remain a close-up throughout the video where the subject fills most of the frame?",
+        "Is the video consistently framed as a close-up, capturing key details of the subject?",
+        "Does the video maintain a close-up perspective where the subject's face, hands, or defining features remain visible?",
+        "Is the entire sequence shot in close-up, framing the subject closely while providing enough context?",
+        "Does the video keep a consistent close-up that emphasizes specific portions of the subject?",
+        "Is the subject consistently occupying 50%-100% of the frame's height or width throughout?",
+        "Does the video maintain a close-up focus on the subject's defining features?",
+        "Is the entire sequence shot at close range to emphasize the subject's details?"
+    ],
+    "def_prompt": [
+        "A video that maintains a close-up shot throughout, consistently highlighting a distinct part of the subject while maintaining context."
+    ],
+    "alt_prompt": [
+        "A video shot entirely in close-up where the subject's defining features fill most of the frame.",
+        "A sequence maintaining a close-up shot that emphasizes specific details of the subject.",
+        "A video consistently framed in close-up, providing tight yet identifiable framing.",
+        "A sequence shot entirely in close-up, focusing on the subject's key features.",
+        "A video maintaining close-up framing while preserving essential context.",
+        "A shot that consistently captures the subject closely with surrounding context.",
+        "A video where the subject consistently occupies 50%-100% of the frame.",
+        "A sequence maintaining close-up focus on the subject's defining characteristics.",
+        "A video shot entirely in close-up to enhance the subject's presence."
+    ],
+    "pos_rule_str": "self.shot_size_info['start'] == 'close_up' and self.shot_size_info['end'] == 'close_up'",
+    "neg_rule_str": "not (self.shot_size_info['start'] == 'close_up' and self.shot_size_info['end'] == 'close_up')",
+    "easy_neg_rule_str": {},
+    "hard_neg_rule_str": {}
+}

--- a/labels/cam_setup/shot_size/is_always/shot_size_is_extreme_close_up.json
+++ b/labels/cam_setup/shot_size/is_always/shot_size_is_extreme_close_up.json
@@ -1,0 +1,34 @@
+{
+    "label": "Shot Size Is Extreme Close Up",
+    "label_name": "shot_size_is_extreme_close_up",
+    "def_question": [
+        "Does the video maintain an extreme close-up shot throughout, focusing very tightly on specific details or features?"
+    ],
+    "alt_question": [
+        "Is the entire video filmed in extreme close-up, showing minute details?",
+        "Does the shot remain an extreme close-up throughout, focusing on very specific features?",
+        "Is the video consistently framed as an extreme close-up, showing intimate details?",
+        "Does the video maintain an extreme close-up that reveals fine details or textures?",
+        "Is the entire sequence shot in extreme close-up, emphasizing tiny details?",
+        "Does the video keep a consistent extreme close-up that magnifies specific elements?",
+        "Is the subject's detail consistently filling the entire frame throughout?",
+        "Does the video maintain an extreme close-up focus that reveals intricate features?"
+    ],
+    "def_prompt": [
+        "A video that maintains an extreme close-up shot throughout, focusing very tightly on specific details or features."
+    ],
+    "alt_prompt": [
+        "A video shot entirely in extreme close-up showing minute details.",
+        "A sequence maintaining an extreme close-up that emphasizes specific features.",
+        "A video consistently framed in extreme close-up, revealing intimate details.",
+        "A sequence shot entirely in extreme close-up, focusing on fine textures.",
+        "A video maintaining extreme close-up framing to highlight specific elements.",
+        "A shot that consistently captures the subject's finest details.",
+        "A video where intimate details fill the entire frame throughout.",
+        "A sequence maintaining extreme close-up focus on intricate features."
+    ],
+    "pos_rule_str": "self.shot_size_info['start'] == 'extreme_close_up' and self.shot_size_info['end'] == 'extreme_close_up'",
+    "neg_rule_str": "not (self.shot_size_info['start'] == 'extreme_close_up' and self.shot_size_info['end'] == 'extreme_close_up')",
+    "easy_neg_rule_str": {},
+    "hard_neg_rule_str": {}
+}

--- a/labels/cam_setup/shot_size/is_always/shot_size_is_extreme_wide.json
+++ b/labels/cam_setup/shot_size/is_always/shot_size_is_extreme_wide.json
@@ -1,0 +1,34 @@
+{
+    "label": "Shot Size Is Extreme Wide",
+    "label_name": "shot_size_is_extreme_wide",
+    "def_question": [
+        "Does the video maintain an extreme wide shot throughout, showing a vast area or landscape with subjects appearing very small?"
+    ],
+    "alt_question": [
+        "Is the entire video filmed in an extreme wide shot, capturing a vast expanse?",
+        "Does the shot remain extremely wide throughout, showing the full scope of the environment?",
+        "Is the video consistently framed as an extreme wide shot, emphasizing the grand scale?",
+        "Does the video maintain an extreme wide perspective where subjects appear tiny in the frame?",
+        "Is the entire sequence shot from an extreme distance, showcasing the broader context?",
+        "Does the video keep a consistent extreme wide angle that captures the entire scene?",
+        "Is the environment consistently shown in its entirety throughout the video?",
+        "Does the video maintain an extreme wide focus that emphasizes the vastness of the setting?"
+    ],
+    "def_prompt": [
+        "A video that maintains an extreme wide shot throughout, showing a vast area or landscape with subjects appearing very small."
+    ],
+    "alt_prompt": [
+        "A video shot entirely in extreme wide angle showing vast expanses.",
+        "A sequence maintaining an extreme wide shot that emphasizes the environment's scale.",
+        "A video consistently framed to show the maximum possible view of the scene.",
+        "A sequence shot entirely from an extreme distance, minimizing subject size.",
+        "A video maintaining extreme wide framing to capture the complete environment.",
+        "A shot that consistently shows the broader context and setting.",
+        "A video where the vast environment dominates the frame throughout.",
+        "A sequence maintaining an extreme wide perspective on the scene."
+    ],
+    "pos_rule_str": "self.shot_size_info['start'] == 'extreme_wide' and self.shot_size_info['end'] == 'extreme_wide'",
+    "neg_rule_str": "not (self.shot_size_info['start'] == 'extreme_wide' and self.shot_size_info['end'] == 'extreme_wide')",
+    "easy_neg_rule_str": {},
+    "hard_neg_rule_str": {}
+}

--- a/labels/cam_setup/shot_size/is_always/shot_size_is_full.json
+++ b/labels/cam_setup/shot_size/is_always/shot_size_is_full.json
@@ -1,0 +1,34 @@
+{
+    "label": "Shot Size Is Full",
+    "label_name": "shot_size_is_full",
+    "def_question": [
+        "Does the video maintain a full shot throughout, showing the entire subject from head to toe?"
+    ],
+    "alt_question": [
+        "Is the entire video filmed in a full shot, capturing the complete subject?",
+        "Does the shot remain full-length throughout, showing subjects from head to toe?",
+        "Is the video consistently framed to show the full height of subjects?",
+        "Does the video maintain a full-body perspective of the subjects?",
+        "Is the entire sequence shot to include complete figures?",
+        "Does the video keep a consistent full shot that shows entire subjects?",
+        "Are subjects shown in their entirety throughout the video?",
+        "Does the video maintain a full-body framing from start to finish?"
+    ],
+    "def_prompt": [
+        "A video that maintains a full shot throughout, showing the entire subject from head to toe."
+    ],
+    "alt_prompt": [
+        "A video shot entirely in full view showing complete subjects.",
+        "A sequence maintaining a full shot that captures entire figures.",
+        "A video consistently framed to show subjects from head to toe.",
+        "A sequence shot entirely to include complete subjects.",
+        "A video maintaining full-body framing of all subjects.",
+        "A shot that consistently captures subjects in their entirety.",
+        "A video where complete figures are visible throughout.",
+        "A sequence maintaining full-body perspective of subjects."
+    ],
+    "pos_rule_str": "self.shot_size_info['start'] == 'full' and self.shot_size_info['end'] == 'full'",
+    "neg_rule_str": "not (self.shot_size_info['start'] == 'full' and self.shot_size_info['end'] == 'full')",
+    "easy_neg_rule_str": {},
+    "hard_neg_rule_str": {}
+}

--- a/labels/cam_setup/shot_size/is_always/shot_size_is_medium.json
+++ b/labels/cam_setup/shot_size/is_always/shot_size_is_medium.json
@@ -1,0 +1,34 @@
+{
+    "label": "Shot Size Is Medium",
+    "label_name": "shot_size_is_medium",
+    "def_question": [
+        "Does the video maintain a medium shot throughout, showing subjects from approximately waist up?"
+    ],
+    "alt_question": [
+        "Is the entire video filmed in medium shot, framing subjects from the waist up?",
+        "Does the shot remain at medium distance throughout the video?",
+        "Is the video consistently framed as a medium shot, showing upper body portions?",
+        "Does the video maintain a medium perspective where subjects are visible from waist up?",
+        "Is the entire sequence shot from a medium distance, focusing on the upper body?",
+        "Does the video keep a consistent medium framing that shows subjects partially?",
+        "Are subjects consistently shown from the waist up throughout the video?",
+        "Does the video maintain a medium-distance focus throughout?"
+    ],
+    "def_prompt": [
+        "A video that maintains a medium shot throughout, showing subjects from approximately waist up."
+    ],
+    "alt_prompt": [
+        "A video shot entirely in medium view showing subjects from waist up.",
+        "A sequence maintaining a medium shot that captures upper body portions.",
+        "A video consistently framed at medium distance.",
+        "A sequence shot entirely from medium range, focusing on upper bodies.",
+        "A video maintaining medium framing to capture partial figures.",
+        "A shot that consistently shows subjects from the waist up.",
+        "A video where subjects are seen at medium distance throughout.",
+        "A sequence maintaining medium-range perspective of subjects."
+    ],
+    "pos_rule_str": "self.shot_size_info['start'] == 'medium' and self.shot_size_info['end'] == 'medium'",
+    "neg_rule_str": "not (self.shot_size_info['start'] == 'medium' and self.shot_size_info['end'] == 'medium')",
+    "easy_neg_rule_str": {},
+    "hard_neg_rule_str": {}
+}

--- a/labels/cam_setup/shot_size/is_always/shot_size_is_medium_close_up.json
+++ b/labels/cam_setup/shot_size/is_always/shot_size_is_medium_close_up.json
@@ -1,0 +1,34 @@
+{
+    "label": "Shot Size Is Medium Close Up",
+    "label_name": "shot_size_is_medium_close_up",
+    "def_question": [
+        "Does the video maintain a medium close-up shot throughout, showing subjects from approximately chest up?"
+    ],
+    "alt_question": [
+        "Is the entire video filmed in medium close-up, framing subjects from chest up?",
+        "Does the shot remain at medium close-up distance throughout?",
+        "Is the video consistently framed as a medium close-up, showing upper chest and head?",
+        "Does the video maintain a medium close-up perspective focusing on the upper torso and face?",
+        "Is the entire sequence shot from a medium close-up distance?",
+        "Does the video keep a consistent medium close-up framing?",
+        "Are subjects consistently shown from chest up throughout the video?",
+        "Does the video maintain a medium close-up focus that emphasizes facial expressions?"
+    ],
+    "def_prompt": [
+        "A video that maintains a medium close-up shot throughout, showing subjects from approximately chest up."
+    ],
+    "alt_prompt": [
+        "A video shot entirely in medium close-up showing subjects from chest up.",
+        "A sequence maintaining a medium close-up that captures upper torso and face.",
+        "A video consistently framed at medium close-up distance.",
+        "A sequence shot entirely from medium close-up range.",
+        "A video maintaining medium close-up framing to emphasize expressions.",
+        "A shot that consistently shows subjects from chest level up.",
+        "A video where subjects are seen at medium close-up distance throughout.",
+        "A sequence maintaining medium close-up perspective of subjects."
+    ],
+    "pos_rule_str": "self.shot_size_info['start'] == 'medium_close_up' and self.shot_size_info['end'] == 'medium_close_up'",
+    "neg_rule_str": "not (self.shot_size_info['start'] == 'medium_close_up' and self.shot_size_info['end'] == 'medium_close_up')",
+    "easy_neg_rule_str": {},
+    "hard_neg_rule_str": {}
+}

--- a/labels/cam_setup/shot_size/is_always/shot_size_is_medium_full.json
+++ b/labels/cam_setup/shot_size/is_always/shot_size_is_medium_full.json
@@ -1,0 +1,34 @@
+{
+    "label": "Shot Size Is Medium Full",
+    "label_name": "shot_size_is_medium_full",
+    "def_question": [
+        "Does the video maintain a medium full shot throughout, showing subjects from approximately knee up?"
+    ],
+    "alt_question": [
+        "Is the entire video filmed in medium full shot, framing subjects from knee up?",
+        "Does the shot remain at medium full distance throughout the video?",
+        "Is the video consistently framed as a medium full shot, showing subjects from knees to head?",
+        "Does the video maintain a medium full perspective where most of the body is visible?",
+        "Is the entire sequence shot from a medium full distance?",
+        "Does the video keep a consistent medium full framing that shows subjects from knee level?",
+        "Are subjects consistently shown from knees up throughout the video?",
+        "Does the video maintain a medium full focus throughout?"
+    ],
+    "def_prompt": [
+        "A video that maintains a medium full shot throughout, showing subjects from approximately knee up."
+    ],
+    "alt_prompt": [
+        "A video shot entirely in medium full view showing subjects from knee up.",
+        "A sequence maintaining a medium full shot that captures most of the body.",
+        "A video consistently framed at medium full distance.",
+        "A sequence shot entirely from medium full range.",
+        "A video maintaining medium full framing to show subjects from knees up.",
+        "A shot that consistently shows subjects from knee level.",
+        "A video where subjects are seen at medium full distance throughout.",
+        "A sequence maintaining medium full perspective of subjects."
+    ],
+    "pos_rule_str": "self.shot_size_info['start'] == 'medium_full' and self.shot_size_info['end'] == 'medium_full'",
+    "neg_rule_str": "not (self.shot_size_info['start'] == 'medium_full' and self.shot_size_info['end'] == 'medium_full')",
+    "easy_neg_rule_str": {},
+    "hard_neg_rule_str": {}
+}

--- a/labels/cam_setup/shot_size/is_always/shot_size_is_wide.json
+++ b/labels/cam_setup/shot_size/is_always/shot_size_is_wide.json
@@ -1,0 +1,34 @@
+{
+    "label": "Shot Size Is Wide",
+    "label_name": "shot_size_is_wide",
+    "def_question": [
+        "Does the video maintain a wide shot throughout, showing the full subject and their immediate surroundings?"
+    ],
+    "alt_question": [
+        "Is the entire video filmed in wide shot, capturing subjects and their environment?",
+        "Does the shot remain wide throughout, showing both subjects and surroundings?",
+        "Is the video consistently framed as a wide shot, including contextual space?",
+        "Does the video maintain a wide perspective where subjects and setting are visible?",
+        "Is the entire sequence shot from a wide angle, showing the broader scene?",
+        "Does the video keep a consistent wide framing that includes environmental context?",
+        "Are subjects and their surroundings consistently shown throughout?",
+        "Does the video maintain a wide focus that captures the complete setting?"
+    ],
+    "def_prompt": [
+        "A video that maintains a wide shot throughout, showing the full subject and their immediate surroundings."
+    ],
+    "alt_prompt": [
+        "A video shot entirely in wide view showing subjects and environment.",
+        "A sequence maintaining a wide shot that captures the complete scene.",
+        "A video consistently framed to show subjects in their context.",
+        "A sequence shot entirely from wide range, including surroundings.",
+        "A video maintaining wide framing to capture the broader setting.",
+        "A shot that consistently shows subjects and their environment.",
+        "A video where subjects and surroundings are visible throughout.",
+        "A sequence maintaining wide perspective of the entire scene."
+    ],
+    "pos_rule_str": "self.shot_size_info['start'] == 'wide' and self.shot_size_info['end'] == 'wide'",
+    "neg_rule_str": "not (self.shot_size_info['start'] == 'wide' and self.shot_size_info['end'] == 'wide')",
+    "easy_neg_rule_str": {},
+    "hard_neg_rule_str": {}
+}


### PR DESCRIPTION
Added 8 new JSON files in labels/cam_setup/shot_size/is_always/ directory:

1. shot_size_is_close_up.json
2. shot_size_is_extreme_close_up.json
3. shot_size_is_extreme_wide.json
4. shot_size_is_full.json
5. shot_size_is_medium.json
6. shot_size_is_medium_close_up.json
7. shot_size_is_medium_full.json
8. shot_size_is_wide.json

Each file follows the same structure as existing files in the repository, with appropriate labels, questions, prompts, and rule strings for the is_always condition.